### PR TITLE
Various Improvements: Large refractor of entities to remove duplicated fields and add control fields.

### DIFF
--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -69,6 +69,17 @@ abstract class abstract_nudge_db {
     }
 
     /**
+     * Shorthand for {@see static::save} then {@see static::get_by_id}.
+     *
+     * @param T $instance
+     * @return T|null
+     */
+    public static function create_or_refresh(abstract_nudge_entity $instance): ?abstract_nudge_entity {
+        $instanceid = static::save($instance);
+        return static::get_by_id($instanceid);
+    }
+
+    /**
      * @param int $id
      * @throws coding_exception
      * @return T|null

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -25,6 +25,8 @@ use stdClass;
 /**
  * Abstract DML to wrap DB records returned as STDClass in more type hinted entity.
  *
+ * @todo Handle IDs that a less than 0 with nice moodle exception saying "can't find entityclass with id etc".
+ *
  * Coding exception used throughout and are not documented with @\throws since they should not occur at runtime.
  *
  * @package     local_nudge\dml

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -22,6 +22,14 @@ use coding_exception;
 use local_nudge\local\abstract_nudge_entity;
 use stdClass;
 
+use function nudge_mockable_time as time;
+
+defined('MOODLE_INTERNAL') || die();
+
+/** @var \core_config $CFG */
+global $CFG;
+require_once(__DIR__ . '/../../lib.php');
+
 /**
  * Abstract DML to wrap DB records returned as STDClass in more type hinted entity.
  *
@@ -197,15 +205,16 @@ abstract class abstract_nudge_db {
      * Persists or create a database row from a {@see T} instance.
      *
      * @param T $instance
+     * @return int
      */
-    public static function save(abstract_nudge_entity $instance) {
+    public static function save(abstract_nudge_entity $instance): int {
         /** @var \moodle_database $DB */
         /** @var stdClass $USER */
         global $DB, $USER;
 
         $instance = clone $instance;
 
-        $instance->lastmodified = \time();
+        $instance->lastmodified = time();
         $instance->lastmodifiedby = $USER->id;
 
         if ($instance->id === null || $instance->id === 0) {
@@ -213,7 +222,7 @@ abstract class abstract_nudge_db {
             static::populate_defaults($instance);
 
             $instance->createdby = $USER->id;
-            $instance->timecreated = \time();
+            $instance->timecreated = time();
 
             self::call_hook('on_before_create', $instance);
 

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -200,15 +200,20 @@ abstract class abstract_nudge_db {
      */
     public static function save(abstract_nudge_entity $instance) {
         /** @var \moodle_database $DB */
-        global $DB;
+        /** @var stdClass $USER */
+        global $DB, $USER;
 
         $instance = clone $instance;
 
         $instance->lastmodified = \time();
+        $instance->lastmodifiedby = $USER->id;
 
         if ($instance->id === null || $instance->id === 0) {
             // Add defaults they exist and are null in the current record.
             static::populate_defaults($instance);
+
+            $instance->createdby = $USER->id;
+            $instance->timecreated = \time();
 
             self::call_hook('on_before_create', $instance);
 
@@ -221,6 +226,8 @@ abstract class abstract_nudge_db {
 
         self::call_hook('on_before_save', $instance);
 
+        unset($instance->createdby);
+        unset($instance->timecreated);
         $DB->update_record(static::$table, $instance);
 
         self::call_hook('on_after_save', $instance->id);

--- a/classes/dml/nudge_notification_db.php
+++ b/classes/dml/nudge_notification_db.php
@@ -59,7 +59,7 @@ class nudge_notification_db extends abstract_nudge_db {
      * {@inheritDoc}
      */
     public static function delete(?int $id = null): void {
-        // Could just use that SQL thingie here.
+        // Could just use an SQL key here.
         parent::delete($id);
 
         $lremoves = nudge_db::get_all_filtered(['linkedlearnernotificationid' => $id]);

--- a/classes/dto/nudge_notification_form_data.php
+++ b/classes/dto/nudge_notification_form_data.php
@@ -15,8 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * This class is the base entity representation.
- *
  * @package     local_nudge\dto
  * @author      Liam Kearney <liam@sproutlabs.com.au>
  * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }

--- a/classes/form/nudge/delete.php
+++ b/classes/form/nudge/delete.php
@@ -41,7 +41,10 @@ class delete extends \moodleform {
         $mform->addElement('hidden', 'courseid');
         $mform->setType('courseid', PARAM_INT);
 
-        $mform->addElement('html', '<div class="alert alert-danger">Are you sure you want delete this nudge?<div><br/>');
+        $deletestring = \get_string('form_nudge_deleteconfirm', 'local_nudge');
+        $mform->addElement('html', <<<HTML
+            <div class="alert alert-danger">{$deletestring}<div><br/>
+        HTML);
 
         $this->add_action_buttons(true, get_string('delete'));
     }

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -199,6 +199,7 @@ class edit extends moodleform {
             throw new coding_exception(\sprintf('You must provide a instance of %s to this form %s.', nudge::class, __CLASS__));
         }
 
+        // TODO This is a bugged.
         $reltime = ($nudge->remindertypeperiod === null || $nudge->remindertypeperiod === 0)
             ? \DAYSECS
             : $nudge->remindertypeperiod;

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -226,7 +226,7 @@ class edit extends moodleform {
      * @return array<string, string>
      */
     public function validation($data, $files) {
-        $errors = [];
+        $errors = parent::validation($data, $files);
 
         // Validate it: Has notifications linked for the selected REMINDER_RECIPIENT type.
         if (!empty($data['reminderrecipient'])) {

--- a/classes/form/nudge_notification/delete.php
+++ b/classes/form/nudge_notification/delete.php
@@ -38,7 +38,10 @@ class delete extends \moodleform {
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
 
-        $mform->addElement('html', '<div class="alert alert-danger">Are you sure you want delete this notification?<div><br/>');
+        $deletestring = \get_string('form_notification_deleteconfirm', 'local_nudge');
+        $mform->addElement('html', <<<HTML
+            <div class="alert alert-danger">{$deletestring}<div><br/>
+        HTML);
 
         // TODO: Add checkbox here to also delete notification translations that is checked by default.
 

--- a/classes/form/nudge_notification/edit.php
+++ b/classes/form/nudge_notification/edit.php
@@ -303,4 +303,34 @@ class edit extends moodleform {
 
         $this->_form->setDefaults($defaults);
     }
+
+    /**
+     * Validation of this form.
+     *
+     * @param array<string, mixed> $data
+     * @param array<string, string> $files
+     * @return array<string, string>
+     */
+    public function validation($data, $files) {
+        $errors = parent::validation($data, $files);
+
+        // Validate it: Only has one translation for each language.
+        if (!empty($data['lang'])) {
+
+            $langs = $data['lang'];
+
+            if (count($langs) !== count(\array_unique($langs))) {
+                // If duplicates are found mark every single language as invalid.
+                // Not sure if there is a better element to display this on.
+                for ($i = 0; $i < count($langs); $i++) {
+                    $errors["lang[{$i}]"] = get_string(
+                        'validation_notification_duplicatelangs',
+                        'local_nudge'
+                    );
+                }
+            }
+        }
+
+        return $errors;
+    }
 }

--- a/classes/form/nudge_notification/edit.php
+++ b/classes/form/nudge_notification/edit.php
@@ -120,11 +120,11 @@ class edit extends moodleform {
         $helptext = get_string('form_notification_templatevar_help', 'local_nudge');
         /** @var array<string> */
         $helpitems = [];
-        foreach (nudge::TEMPLATE_VARIABLES as $templatevariable) {
+        foreach (\array_keys(nudge::TEMPLATE_VARIABLES) as $templatevariable) {
             [$templateobj, $templatename] = \explode('_', \trim($templatevariable, '{}'));
             $helpitems[] = "<li><code>$templatevariable</code> -> {$templateobj}'s {$templatename}</li>";
         }
-        $helpitems = \implode('\\n', $helpitems);
+        $helpitems = \implode('', $helpitems);
         $mform->addElement('header', 'templatevarinfohdr', get_string('form_notification_templatevar_title', 'local_nudge'));
         $mform->addElement(
             'html',

--- a/classes/local/abstract_nudge_entity.php
+++ b/classes/local/abstract_nudge_entity.php
@@ -60,7 +60,25 @@ abstract class abstract_nudge_entity {
      */
     public $id = null;
 
-    // TODO created date & last user/time-modifed.
+    /**
+     * @var int|null ID of an {@see \core\entity\user} that created this entity.
+     */
+    public $createdby = null;
+
+    /**
+     * @var int|null Timestamp representing the time this entity was created.
+     */
+    public $timecreated = null;
+
+    /**
+     * @var int|null ID of an {@see \core\entity\user} that last modified this entity.
+     */
+    public $lastmodifiedby = null;
+
+    /**
+     * @var int|null Timestamp representing the last time this entity was modified.
+     */
+    public $lastmodified = null;
 
     /**
      * Constructs an instance of this record from an array or stdClass.
@@ -79,6 +97,10 @@ abstract class abstract_nudge_entity {
         if ($data == null) {
 
             $this->id = (int) $this->id;
+            $this->createdby = (int) $this->createdby;
+            $this->timecreated = (int) $this->timecreated;
+            $this->lastmodifiedby = (int) $this->lastmodifiedby;
+            $this->lastmodified = (int) $this->lastmodified;
 
             $this->cast_fields();
 
@@ -119,6 +141,10 @@ abstract class abstract_nudge_entity {
         }
 
         $this->id = (int) $this->id;
+        $this->createdby = (int) $this->createdby;
+        $this->timecreated = (int) $this->timecreated;
+        $this->lastmodifiedby = (int) $this->lastmodifiedby;
+        $this->lastmodified = (int) $this->lastmodified;
 
         $this->cast_fields();
     }

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -116,11 +116,6 @@ class nudge extends abstract_nudge_entity {
     public $isenabled = null;
 
     /**
-     * @var int|null The timestamp this nudge instance was last modified at.
-     */
-    public $lastmodified = null;
-
-    /**
      * @var string|null The the reminder recipients of this nudge.
      */
     public $reminderrecipient = null;

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -42,11 +42,6 @@ class nudge_notification extends abstract_nudge_entity {
     public $title = null;
 
     /**
-     * @var int|null Last modified time stored as a timestamp.
-     */
-    public $lastmodified = null;
-
-    /**
      * @var int|null The id of a {@see core_user} to send notifications from.
      */
     public $userfromid = null;

--- a/classes/task/nudge_task.php
+++ b/classes/task/nudge_task.php
@@ -27,11 +27,14 @@ use local_nudge\dml\nudge_user_db;
 use local_nudge\local\nudge;
 use local_nudge\local\nudge_user;
 
+use function nudge_mockable_time as time;
+
 defined('MOODLE_INTERNAL') || die();
 
 /** @var \core_config $CFG */
 global $CFG;
-require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/completionlib.php');;
+require_once(__DIR__ . '/../../lib.php');
 
 /**
  * @package     local_nudge\task
@@ -94,7 +97,7 @@ class nudge_task extends scheduled_task {
                     $timetoremindofendofcourse = $nudgescourse->enddate - $enabledinstance->remindertypeperiod;
 
                     // NO-OP
-                    if ($timetoremindofendofcourse < \time()) {
+                    if ($timetoremindofendofcourse < time()) {
                         break;
                     }
 
@@ -126,7 +129,7 @@ class nudge_task extends scheduled_task {
         // TODO handle: \enrol_get_enrolment_end()
 
         // No more need to recurr the course has ended.
-        if ($nudgescourse->enddate < \time()) {
+        if ($nudgescourse->enddate < time()) {
             $nudge->isenabled = false;
             nudge_db::save($nudge);
 
@@ -163,7 +166,7 @@ class nudge_task extends scheduled_task {
             }
 
             // NO-OP for this user.
-            if ($previoustiming->recurrancetime > \time()) {
+            if ($previoustiming->recurrancetime > time()) {
                 continue;
             }
 
@@ -171,7 +174,7 @@ class nudge_task extends scheduled_task {
             $nudge->trigger($incompleteuser);
 
             // Setup the next period for this user.
-            $previoustiming->recurrancetime = \time() + $nudge->remindertypeperiod;
+            $previoustiming->recurrancetime = time() + $nudge->remindertypeperiod;
             nudge_user_db::save($previoustiming);
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "liam@sproutlabs.com.au"
         }
     ],
+    "require": {
+        "php": ">=7.4"
+    },
     "require-dev": {
         "phpstan/phpstan": "^1.4"
     }

--- a/db/install.xml
+++ b/db/install.xml
@@ -7,11 +7,14 @@
     <TABLE NAME="local_nudge" COMMENT="Stores instances of Nudge that indicate and provide metadata for Courses who want Nudge reminders">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user that created this Nudge instance." />
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="A timestamp for when this Nudge instance was created." />
+        <FIELD NAME="lastmodifiedby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last user that modified this Nudge instance." />
+        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge instance was modified." />
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Course that this nudge instance is linked to."/>
         <FIELD NAME="linkedlearnernotificationid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="The has one for a nudge_notification that will be sent to the Learner on nudge trigger."/>
         <FIELD NAME="linkedmanagernotificationid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="The has one for a nudge_notification that will be sent to the Manager on nudge trigger."/>
         <FIELD NAME="isenabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Indicates that this nudge instance is enabled and ready to send messages."/>
-        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge instance was modified."/>
         <FIELD NAME="reminderrecipient" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="Enum indicating who should receive reminders from this Nudge instance. See the local_nudge\\local\\nudge for details."/>
         <FIELD NAME="remindertype" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="Enum representing this nudge's method of determining the appropriate date to nudge on."/>
         <FIELD NAME="remindertypefixeddate" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="See entity comment on local_nudge\\local\\nudge"/>
@@ -30,7 +33,10 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="title" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Title for this notification template."/>
-        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Timestamp this notification was last modified at."/>
+        <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user that created this Nudge Notification instance." />
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="A timestamp for when this Nudge Notification instance was created." />
+        <FIELD NAME="lastmodifiedby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last user that modified this Nudge Notification instance." />
+        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge Notification instance was modified." />
         <FIELD NAME="userfromid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="A has one to an instance of user that this notification can be sent from. Will use core's no-reply user if null."/>
       </FIELDS>
       <KEYS>
@@ -41,6 +47,10 @@
     <TABLE NAME="local_nudge_notif_content" COMMENT="'nudge_notification_content's have one nudge_notification and provide translations/content for it.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user that created this Nudge Notification Content instance." />
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="A timestamp for when this Nudge Notification Content instance was created." />
+        <FIELD NAME="lastmodifiedby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last user that modified this Nudge Notification Content instance." />
+        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge Notification Content instance was modified." />
         <FIELD NAME="nudgenotificationid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="has one to a nudge_notification"/>
         <FIELD NAME="lang" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Language for this notification content"/>
         <FIELD NAME="subject" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Subject for this notification content"/>
@@ -54,6 +64,10 @@
     <TABLE NAME="local_nudge_user" COMMENT="This table joins between a nudge instance and a user to keep track of the recurrence time if relative to the users enrollment date.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user that created this Nudge User instance." />
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="A timestamp for when this Nudge User instance was created." />
+        <FIELD NAME="lastmodifiedby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last user that modified this Nudge User instance." />
+        <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge User instance was modified." />
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="has_one to user."/>
         <FIELD NAME="nudgeid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="has one to nudge."/>
         <FIELD NAME="recurrancetime" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Used to track individual enrollments for recurring notifications."/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -14,7 +14,7 @@
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Course that this nudge instance is linked to."/>
         <FIELD NAME="linkedlearnernotificationid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="The has one for a nudge_notification that will be sent to the Learner on nudge trigger."/>
         <FIELD NAME="linkedmanagernotificationid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="The has one for a nudge_notification that will be sent to the Manager on nudge trigger."/>
-        <FIELD NAME="isenabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Indicates that this nudge instance is enabled and ready to send messages."/>
+        <FIELD NAME="isenabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Indicates that this nudge instance is enabled and ready to send messages." />
         <FIELD NAME="reminderrecipient" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="Enum indicating who should receive reminders from this Nudge instance. See the local_nudge\\local\\nudge for details."/>
         <FIELD NAME="remindertype" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="Enum representing this nudge's method of determining the appropriate date to nudge on."/>
         <FIELD NAME="remindertypefixeddate" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="See entity comment on local_nudge\\local\\nudge"/>
@@ -22,8 +22,8 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="linkedlearnernotificationkey" TYPE="foreign" FIELDS="linkedlearnernotificationid" REFTABLE="nudge_notification" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="Foreign key constraint for a nudge_notification for the learner."/>
-        <KEY NAME="linkedmanagernotificationkey" TYPE="foreign" FIELDS="linkedmanagernotificationid" REFTABLE="nudge_notification" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="Foreign key constraint for a nudge_notification for the manager."/>
+        <KEY NAME="linkedlearnernotificationkey" TYPE="foreign" FIELDS="linkedlearnernotificationid" REFTABLE="nudge_notification" REFFIELDS="id" COMMENT="Foreign key constraint for a nudge_notification for the learner." />
+        <KEY NAME="linkedmanagernotificationkey" TYPE="foreign" FIELDS="linkedmanagernotificationid" REFTABLE="nudge_notification" REFFIELDS="id" COMMENT="Foreign key constraint for a nudge_notification for the manager." />
       </KEYS>
       <INDEXES>
         <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
@@ -32,16 +32,16 @@
     <TABLE NAME="local_nudge_notification" COMMENT="Stores instances of a Nudge Notification. A nudge notification has many 'nudge_notification_content's to store translation for each language.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="title" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Title for this notification template."/>
         <FIELD NAME="createdby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user that created this Nudge Notification instance." />
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="A timestamp for when this Nudge Notification instance was created." />
         <FIELD NAME="lastmodifiedby" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last user that modified this Nudge Notification instance." />
         <FIELD NAME="lastmodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The last time this Nudge Notification instance was modified." />
+        <FIELD NAME="title" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Title for this notification template." />
         <FIELD NAME="userfromid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="A has one to an instance of user that this notification can be sent from. Will use core's no-reply user if null."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="userfromkey" TYPE="foreign" FIELDS="userfromid" REFTABLE="user" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="Foreign key constraint for has one to user."/>
+        <KEY NAME="userfromkey" TYPE="foreign" FIELDS="userfromid" REFTABLE="user" REFFIELDS="id" COMMENT="Foreign key constraint for has one to user." />
       </KEYS>
     </TABLE>
     <TABLE NAME="local_nudge_notif_content" COMMENT="'nudge_notification_content's have one nudge_notification and provide translations/content for it.">
@@ -58,7 +58,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="nudgenotificationkey" TYPE="foreign" FIELDS="nudgenotificationid" REFTABLE="nudge_notification" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="has one for nudge_notification"/>
+        <KEY NAME="nudgenotificationkey" TYPE="foreign" FIELDS="nudgenotificationid" REFTABLE="nudge_notification" REFFIELDS="id" COMMENT="has one for nudge_notification" />
       </KEYS>
     </TABLE>
     <TABLE NAME="local_nudge_user" COMMENT="This table joins between a nudge instance and a user to keep track of the recurrence time if relative to the users enrollment date.">
@@ -74,8 +74,8 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="userkey" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="has one key for user"/>
-        <KEY NAME="nudgekey" TYPE="foreign" FIELDS="nudgeid" REFTABLE="nudge" REFFIELDS="id" DEFERREDINSTALL="true" COMMENT="has one key for nudge."/>
+        <KEY NAME="userkey" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id" COMMENT="has one key for user" />
+        <KEY NAME="nudgekey" TYPE="foreign" FIELDS="nudgeid" REFTABLE="nudge" REFFIELDS="id" COMMENT="has one key for nudge." />
       </KEYS>
     </TABLE>
   </TABLES>

--- a/edit_nudge.php
+++ b/edit_nudge.php
@@ -36,6 +36,7 @@ require_once($CFG->libdir . '/adminlib.php');
 
 $nudgeid = \required_param('id', \PARAM_INT);
 $courseid = \required_param('courseid', \PARAM_INT);
+// TODO: CourseID doesn't exist.
 
 \require_login($courseid);
 $context = \context_course::instance($courseid);

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -40,6 +40,8 @@ $string['manage_nudge_add']                         =       'Add a Nudge';
 
 // Nudge Notification
 $string['manage_notification_add']                  =       'Add a Nudge Notification';
+
+
 // ---------------------------------------
 //              EDIT FORMS
 // ---------------------------------------
@@ -90,6 +92,8 @@ $string['form_nudge_reminderdatecoruseend_help']    =       <<<EOF
 TODO
 EOF;
 
+$string['form_nudge_deleteconfirm']                 =       'Are you sure you want delete this nudge?';
+
 // Notification
 $string['form_notification_title']                  =       'Add a title';
 
@@ -107,6 +111,9 @@ $string['form_notification_addbody']                =       'Add a body';
 
 $string['form_notification_addprompt']              =       'Add {no} more translation{possible_s}';
 
+$string['form_notification_deleteconfirm']                 =       'Are you sure you want delete this notification?';
+
+
 // ---------------------------------------
 //              ENUM TITLES
 // See: local/nudge/lib.php::nudge_scaffold_select_from_constants()
@@ -120,6 +127,7 @@ $string['reminderdaterelativecourseend']            =       'Reminder Date Relat
 $string['reminderrecipientlearner']                 =       'The Learner';
 $string['reminderrecipientmanagers']                =       'The Learner\'s Managers';
 $string['reminderrecipientboth']                    =       'Both the Learner and their Managers';
+
 
 // ---------------------------------------
 //                  ADMIN
@@ -183,10 +191,10 @@ EOF;
 
 // TODO: convert some of the DML called from the cron to SQL.
 
+
 // ---------------------------------------
 //                 ERRORS
 // ---------------------------------------
-
 $string['expectedunreachable']                      =       'Expected unreachable, It\'s possible a malformed database value was encountered.';
 $string['nudgenotificationdoesntexist']             =       'Can\'t find Nudge Notification with the ID: {$a}';
 $string['nudgedoesntexist']                         =       'Can\'t find Nudge with the ID: {$a}';
@@ -195,7 +203,6 @@ $string['cantmatchmanager']                         =       'The option to match
 // ---------------------------------------
 //               VALIDATION
 // ---------------------------------------
-
 // Nudge
 $string['validation_nudge_neednotifications']       =       'The selected recipient type was: "{$a}" but there wasn\'t wasn\'t enough notifications to cover the recipients.';
 

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -209,3 +209,4 @@ $string['validation_nudge_neednotifications']       =       'The selected recipi
 // Nudge Notification
 $string['validation_notification_needsender']       =       'You must set a sender';
 $string['validation_notification_needtitle']        =       'Title is required for usability';
+$string['validation_notification_duplicatelangs']   =       'Ensure there is only one translation for each language';

--- a/lib.php
+++ b/lib.php
@@ -318,3 +318,19 @@ function nudge_moodle_get_manager_for_user($user): ?stdClass {
     // Null if there is no manager.
     return $manager ?: null;
 }
+
+/**
+ * Return current Unix timestamp, {@see time()} but mockable for tests.
+ *
+ * @return int
+ */
+function nudge_mockable_time(): int {
+    /** @var \core_config $CFG */
+    global $CFG;
+
+    if (!isset($CFG->nudgemocktime)) {
+        return time();
+    } else {
+        return $CFG->nudgemocktime;
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -63,8 +63,12 @@ if ($hassiteconfig) {
     if ($ADMIN->fulltree) {
         /** @var array<stdClass> $customfields */
         $customfields = profile_get_custom_fields();
-        // TODO: Filter these for only text fields or stuff will break :-o !!!
-        // TODO: Warn that this matching is case-insensitive or make it case sense.
+
+        // Filter for only text.
+        $customfields = array_filter($customfields, function (stdClass $customfield) {
+            return $customfield->datatype === 'text';
+        });
+
         $customfieldsselect = (count($customfields) > 0)
             ? array_combine(
                 array_column($customfields, 'shortname'),
@@ -83,7 +87,17 @@ if ($hassiteconfig) {
             new admin_setting_heading(
                 'nudge_admin_manager_heading',
                 get_string('admin_manager_heading', 'local_nudge'),
-                get_string('admin_manager_heading_desc', 'local_nudge'),
+                implode('', [
+                    <<<HTML
+                    <div class="alert alert-danger p-3 pt-4 mt-4">
+                        <p>It is <strong>very important</strong> to note that manager matching is case-insensitive.</p>
+                        <p>If this doesn't work for you feel free to contribute to this plugin via a pull
+                            request or if you are a client get in contact with us via:</p>
+                        <center><a href="mailto:support@sproutlabs.com.au">Support @ Sprout Labs</a></center>
+                    </div>
+                    HTML,
+                    get_string('admin_manager_heading_desc', 'local_nudge'),
+                ]),
             ),
             new admin_setting_configcheckbox(
                 'local_nudge/custommangerresolution',
@@ -95,7 +109,6 @@ if ($hassiteconfig) {
                 'local_nudge/managermatchonfield',
                 get_string('admin_manager_matchon_field', 'local_nudge'),
                 get_string('admin_manager_matchon_field_desc', 'local_nudge'),
-                // Empty select index is less likely to cause an error.
                 'idnumber',
                 $matchonfields,
             ),

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Requires 3.9.0.
-$plugin->version   = 2022022802;
+$plugin->version   = 2022022803;
 $plugin->requires  = 2020061500;
 $plugin->component = 'local_nudge';
 $plugin->release   = 'Development Edition';


### PR DESCRIPTION
This is a large amount of changes from previous days. Mostly just doing a PR mid development for eyes on.

It would definitely help to review commit by commit if you are planning on taking a look.


Namely among them are:
1. `time()` is now mockable. This will help for full testing of the entire crontask.
2. Notification form now fails validation if the user submits more than one translation (`nudge_notification_content`) per language.
3. There is a new function in the abstract DML to make saving a bit easier.

And the biggest one:
I was planning on doing this earlier but I Bikram and I were talking about a particular API's lack of `timecreated` the other day so I went ahead with this.

Test coverage is included but should probably be moved to DML tests since its more DML centric.

