### PR TITLE
Various Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 tests/.phpunit.result.cache
+tests/.phpunit.result
 composer.lock

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "pathMappings": {
+                // Move up from local.
+                "/var/www/html": "${workspaceFolder}/../../"
+            }
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# NOTE
+This plugin is not yet stable.
+There is rename that is going to happen to avoid conflicts with the L&D nudge but we are yet to decide on naming.
+## Maybe:
+Plugin is local_completionreminder and models:
+ - CourseTracker (nudge)
+ - Notification (nudge_notification)
+ - Translation (nudge_notification_content)
+
 # :point_right: Nudge
 > The Nudge plugin for MOODLE and Totara aims to provide a simple way to notify/remind users to revisit their course prior to course completion.
 >> The pugin supports multiple translation, templated messages, recurring remind dates, relative remind dates and the option to remind managers in both Totara *and MOODLE*.

--- a/classes/check/directory/abstract_nudge_access_check.php
+++ b/classes/check/directory/abstract_nudge_access_check.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\check;
+use core\check\result;
+use curl;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+abstract class abstract_nudge_access_check extends check {
+
+    protected static string $name;
+    protected static string $badlevel = result::WARNING;
+    protected static string $filepath;
+    protected static string $desc;
+
+    public function get_name(): string {
+        return 'Nudge - ' . static::$name . ' - access';
+    }
+
+    public function get_result(): result {
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        $result = new result(
+            static::$badlevel,
+            static::$name . ' are web accessible.',
+            static::$desc
+        );
+
+        $curl = new curl();
+        $curl->get($CFG->wwwroot . '/local/nudge/' . static::$filepath);
+        if ($curl->get_info()['http_code'] !== 200) {
+            $result = new result(
+                result::OK,
+                static::$name . ' are not web accessible.',
+                <<<HTML
+                <p>No action is required!</p>
+                HTML
+            );
+        }
+
+        return $result;
+    }
+}

--- a/classes/check/directory/classes_disallowed.php
+++ b/classes/check/directory/classes_disallowed.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class classes_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Classes Directories';
+    protected static string $badlevel = result::WARNING;
+    protected static string $filepath = 'classes/local/nudge.php';
+    protected static string $desc = <<<HTML
+    <p>We'd recommend you disable the serving of nudge's <code>classes</code> directory.</p>
+    <p>Specifically I check <code>classes/local/nudge.php</code>.</p>
+    HTML;
+}

--- a/classes/check/directory/dotfiles_disallowed.php
+++ b/classes/check/directory/dotfiles_disallowed.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class dotfiles_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Dotfiles';
+    protected static string $badlevel = result::CRITICAL;
+    protected static string $filepath = '.gitignore';
+    protected static string $desc = <<<HTML
+    <p>You should take <strong>immediate</strong> to ensure that nudge's dotfiles are not available
+        from the web.</p>
+    <p>Specifically I check <code>.gitignore</code>.</p>
+    HTML;
+}

--- a/classes/check/directory/dotfolders_disallowed.php
+++ b/classes/check/directory/dotfolders_disallowed.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class dotfolders_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Dotfolders';
+    protected static string $badlevel = result::CRITICAL;
+    protected static string $filepath = '.git/logs/HEAD';
+    protected static string $desc = <<<HTML
+    <p>You should take <strong>immediate</strong> to ensure that nudge's dotfolders are not available
+        from the web.</p>
+    <p>Specifically I check <code>.git/logs/HEAD</code>.</p>
+    HTML;
+}

--- a/classes/check/directory/installxml_disallowed.php
+++ b/classes/check/directory/installxml_disallowed.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class installxml_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Install.xml files';
+    protected static string $badlevel = result::CRITICAL;
+    protected static string $filepath = 'db/install.xml';
+    protected static string $desc = <<<HTML
+    <p>You should take <strong>immediate</strong> to ensure that nudge's <code>db/install.xml</code> directory is
+        from the web.</p>
+    <p>Specifically I check <code>db/install.xml</code>.</p>
+    HTML;
+}

--- a/classes/check/directory/markdown_disallowed.php
+++ b/classes/check/directory/markdown_disallowed.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class markdown_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Markdown files';
+    protected static string $badlevel = result::WARNING;
+    protected static string $filepath = 'README.md';
+    protected static string $desc = <<<HTML
+    <p>Its generally a good idea to hide markdown files especially some of the ones in
+            nudge outline directory structure etc.</p>
+    <p>Specifically I check <code>README.md</code>.</p>
+    HTML;
+}

--- a/classes/check/directory/tests_disallowed.php
+++ b/classes/check/directory/tests_disallowed.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\check\directory;
+
+use core\check\result;
+
+/**
+ * @package     local_nudge\check\directory
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @copyright   GNU GPL v3 or later
+ */
+class tests_disallowed extends abstract_nudge_access_check {
+    protected static string $name = 'Tests Directories';
+    protected static string $badlevel = result::WARNING;
+    protected static string $filepath = 'tests/lib_test.php';
+    protected static string $desc = <<<HTML
+    <p>You should take <strong>immediate</strong> to ensure that nudge's <code>tests</code> directory is
+        from the web.</p>
+    <p>Specifically I check <code>tests/lib_test.php</code>.</p>
+    HTML;
+}

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -328,7 +328,7 @@ abstract class abstract_nudge_db {
      * @param T $instance
      * @return void
      */
-    public static function populate_defaults(abstract_nudge_entity $instance): void {
+    public static function populate_defaults(abstract_nudge_entity &$instance): void {
         foreach (static::$entityclass::DEFAULTS as $defaultfield => $value) {
             if ($instance->{$defaultfield} === null ||
                 $instance->{$defaultfield} === '' ||

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -86,8 +86,8 @@ abstract class abstract_nudge_db {
      * @return T|null
      */
     public static function get_by_id(int $id): ?abstract_nudge_entity {
-        if (!\is_int($id) || ($id <= 0)) {
-            throw new coding_exception(\sprintf('You must supply an integer to %s', __METHOD__));
+        if ($id <= 0) {
+            throw new coding_exception(\sprintf('You must supply a positive integer to %s', __METHOD__));
         }
 
         /** @var \moodle_database $DB */
@@ -124,10 +124,6 @@ abstract class abstract_nudge_db {
      * @return T|null
      */
     public static function get_filtered(array $filter): ?abstract_nudge_entity {
-        if (!\is_array($filter)) {
-            throw new coding_exception(\sprintf('You must supply an array to %s as a filter', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 
@@ -143,10 +139,6 @@ abstract class abstract_nudge_db {
      * @return array<T>
      */
     public static function get_all_filtered(array $filter): array {
-        if (!\is_array($filter)) {
-            throw new coding_exception(\sprintf('You must supply an array to %s as a filter', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 
@@ -171,10 +163,6 @@ abstract class abstract_nudge_db {
      * @return T|null Returns a single wrapped instance of {@see T}.
      */
     public static function get_sql(string $sql, ?array $params = null): ?abstract_nudge_entity {
-        if (!\is_string($sql)) {
-            throw new coding_exception(\sprintf('You must supply a string to %s as SQL', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 
@@ -196,10 +184,6 @@ abstract class abstract_nudge_db {
      * @return array<T>
      */
     public static function get_all_sql(string $sql, ?array $params = null): array {
-        if (!\is_string($sql)) {
-            throw new coding_exception(\sprintf('You must supply a string to %s as SQL', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 
@@ -265,15 +249,15 @@ abstract class abstract_nudge_db {
      *
      * WARNING: May delete all {@see T} instances that use `id` as something other than the primary key.
      *
-     * @param int|null $id
      * @codeCoverageIgnore Shallow wrapper.
      *
+     * @param int $id
      * @throws coding_exception
      * @return void
      */
-    public static function delete(?int $id = null): void {
-        if (!\is_int($id) || ($id <= 0)) {
-            throw new coding_exception(\sprintf('You must supply an integer to %s', __METHOD__));
+    public static function delete(int $id): void {
+        if ($id <= 0) {
+            throw new coding_exception(\sprintf('You must supply a positive integer to %s', __METHOD__));
         }
 
         /** @var \moodle_database $DB */
@@ -296,10 +280,6 @@ abstract class abstract_nudge_db {
      * @return void
      */
     public static function delete_all(array $filter): void {
-        if (!\is_array($filter)) {
-            throw new coding_exception(\sprintf('You must supply an array to %s as a filter', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 
@@ -317,10 +297,6 @@ abstract class abstract_nudge_db {
      * @return void
      */
     public static function delete_all_select(string $sql, ?array $params = null): void {
-        if (!\is_string($sql)) {
-            throw new coding_exception(\sprintf('You must supply a string to %s as SQL', __METHOD__));
-        }
-
         /** @var \moodle_database $DB */
         global $DB;
 

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -158,7 +158,7 @@ abstract class abstract_nudge_db {
      * Be careful to ensure your SQL returns all the fields required to be wrapped in
      * an {@see T} or you will encounter a {@throws \UnexpectedValueException}.
      *
-     * @param string $sql MUST return a single instance. {@see static::get_all_sql()} for multiple.
+     * @param string $sql Should return a single instance. {@see static::get_all_sql()} for multiple.
      * @param array|null $params SQL Params.
      * @return T|null Returns a single wrapped instance of {@see T}.
      */
@@ -242,7 +242,7 @@ abstract class abstract_nudge_db {
     }
 
     // These delete functions don't actually wrap an entity so they are a pretty much pointless wrapper around $DB->delete etc.
-    // But it is nice to have everything consistant.
+    // But it is nice to have everything here for consistency.
 
     /**
      * Removes an {@see T} instance from the database.

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -24,10 +24,11 @@ use stdClass;
 
 use function nudge_mockable_time as time;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../lib.php');
-
+// @codeCoverageIgnoreEnd
 /**
  * Abstract DML to wrap DB records returned as STDClass in more type hinted entity.
  *
@@ -38,7 +39,7 @@ require_once(__DIR__ . '/../../lib.php');
  * @package     local_nudge\dml
  * @author      Liam Kearney <liam@sproutlabs.com.au>
  * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
- *
+ * @copyright   GNU GPL v3 or later
  * @template T
  */
 abstract class abstract_nudge_db {
@@ -58,6 +59,8 @@ abstract class abstract_nudge_db {
      *
      * Some IDEs/editors (mine) make __construct public regardless of actual visibility so just call it public.
      * Runtime will fail with the actual visibility if really needed.
+     *
+     * @codeCoverageIgnore
      *
      * @deprecated Don't use this see comments above.
      * @access public
@@ -262,6 +265,8 @@ abstract class abstract_nudge_db {
      * WARNING: May delete all {@see T} instances that use `id` as something other than the primary key.
      *
      * @param int|null $id
+     * @codeCoverageIgnore Shallow wrapper.
+     *
      * @throws coding_exception
      * @return void
      */
@@ -283,6 +288,8 @@ abstract class abstract_nudge_db {
     /**
      * Removes all instances of {@see T} matching the filter.
      *
+     * @codeCoverageIgnore Shallow wrapper.
+     *
      * @todo Bulk hooks.
      * @param array $filter
      * @return void
@@ -300,6 +307,8 @@ abstract class abstract_nudge_db {
 
     /**
      * Removes all instances of {@see T} filtered by SQL.
+     *
+     * @codeCoverageIgnore Shallow wrapper.
      *
      * @todo Bulk hooks.
      * @param string $sql

--- a/classes/dml/abstract_nudge_db.php
+++ b/classes/dml/abstract_nudge_db.php
@@ -224,7 +224,8 @@ abstract class abstract_nudge_db {
         /** @var stdClass $USER */
         global $DB, $USER;
 
-        $instance = clone $instance;
+        // Immutability but more importantly handles re-casting if needed.
+        $instance = new static::$entityclass($instance);
 
         $instance->lastmodified = time();
         $instance->lastmodifiedby = $USER->id;

--- a/classes/dml/nudge_db.php
+++ b/classes/dml/nudge_db.php
@@ -54,7 +54,7 @@ class nudge_db extends abstract_nudge_db {
     }
 
     public static function on_after_create($id): void {
-        $creatednudge = (array) self::get_by_id(\intval($id));
+        $creatednudge = (array) self::get_by_id($id);
         $event = nudge_created::create([
             'context' => ($creatednudge['courseid'] ?? false)
                 ? context_course::instance($creatednudge['courseid'])
@@ -68,7 +68,7 @@ class nudge_db extends abstract_nudge_db {
     }
 
     public static function on_after_save($id): void {
-        $updatednudge = (array) self::get_by_id(\intval($id));
+        $updatednudge = (array) self::get_by_id($id);
         $event = nudge_updated::create([
             'context' => ($updatednudge['courseid'] ?? false)
                 ? context_course::instance($updatednudge['courseid'])
@@ -83,7 +83,7 @@ class nudge_db extends abstract_nudge_db {
 
     // Ideally this would be after it succeeds.
     public static function on_before_delete($id): void {
-        $nudgetobedeleted = (array) self::get_by_id(\intval($id));
+        $nudgetobedeleted = (array) self::get_by_id($id);
         $event = nudge_deleted::create([
             'context' => ($nudgetobedeleted['courseid'] ?? false)
                 ? context_course::instance($nudgetobedeleted['courseid'])

--- a/classes/dml/nudge_db.php
+++ b/classes/dml/nudge_db.php
@@ -32,6 +32,8 @@ use local_nudge\event\nudge_updated;
 use local_nudge\local\nudge;
 
 /**
+ * DML for {@see nudge}
+ *
  * {@inheritDoc}
  * @extends abstract_nudge_db<nudge>
  */
@@ -45,6 +47,9 @@ class nudge_db extends abstract_nudge_db {
 
     /**
      * Returns an array of active instances.
+     *
+     * @codeCoverageIgnore
+     *
      * @return array<nudge>
      */
     public static function get_enabled() {

--- a/classes/event/nudge_created.php
+++ b/classes/event/nudge_created.php
@@ -29,6 +29,8 @@ use moodle_url;
  */
 class nudge_created extends base {
     /**
+     * @codeCoverageIgnore
+     *
      * @return string
      */
     public function get_description() {
@@ -37,6 +39,8 @@ class nudge_created extends base {
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return moodle_url
      */
     public function get_url() {

--- a/classes/event/nudge_created.php
+++ b/classes/event/nudge_created.php
@@ -33,7 +33,7 @@ class nudge_created extends base {
      */
     public function get_description() {
         // phpcs:ignore
-        return "The user with the ID: '{$this->userid}' updated nudge with the ID of: '{$this->other['id']}' for the course ID of: '{$this->other['courseid']}'.";
+        return "The user with the ID: '{$this->userid}' created nudge with the ID of: '{$this->other['id']}' for the course ID of: '{$this->other['courseid']}'.";
     }
 
     /**

--- a/classes/event/nudge_deleted.php
+++ b/classes/event/nudge_deleted.php
@@ -29,6 +29,8 @@ use moodle_url;
  */
 class nudge_deleted extends base {
     /**
+     * @codeCoverageIgnore
+     *
      * @return string
      */
     public function get_description() {
@@ -37,6 +39,8 @@ class nudge_deleted extends base {
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return moodle_url
      */
     public function get_url() {

--- a/classes/event/nudge_updated.php
+++ b/classes/event/nudge_updated.php
@@ -29,6 +29,8 @@ use moodle_url;
  */
 class nudge_updated extends base {
     /**
+     * @codeCoverageIgnore
+     *
      * @return string
      */
     public function get_description() {
@@ -37,6 +39,8 @@ class nudge_updated extends base {
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return moodle_url
      */
     public function get_url() {

--- a/classes/form/nudge/delete.php
+++ b/classes/form/nudge/delete.php
@@ -24,13 +24,12 @@
 
 namespace local_nudge\form\nudge;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/formslib.php');
+// @codeCoverageIgnoreEnd
 
-/**
- * @codeCoverageIgnore
- */
 class delete extends \moodleform {
     public function definition() {
         $mform = $this->_form;
@@ -38,6 +37,7 @@ class delete extends \moodleform {
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
 
+        // This is added for the form to return to the correct management screen.
         $mform->addElement('hidden', 'courseid');
         $mform->setType('courseid', PARAM_INT);
 
@@ -45,6 +45,8 @@ class delete extends \moodleform {
         $mform->addElement('html', <<<HTML
             <div class="alert alert-danger">{$deletestring}<div><br/>
         HTML);
+
+        $mform->addElement('static', 'title');
 
         $this->add_action_buttons(true, get_string('delete'));
     }

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -155,8 +155,17 @@ class edit extends moodleform {
             ]
         );
         $mform->setDefault('reminderdaterelativeenrollmentrecurring', 86400);
-        $mform->hideIf('reminderdaterelativeenrollmentrecurring', 'remindertype', 'neq', nudge::REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING);
-        $mform->addHelpButton('reminderdaterelativeenrollmentrecurring', 'form_nudge_remindertyperelativedaterecurring', 'local_nudge');
+        $mform->hideIf(
+            'reminderdaterelativeenrollmentrecurring',
+            'remindertype',
+            'neq',
+            nudge::REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING
+        );
+        $mform->addHelpButton(
+            'reminderdaterelativeenrollmentrecurring',
+            'form_nudge_remindertyperelativedaterecurring',
+            'local_nudge'
+        );
 
         $mform->addElement(
             'duration',

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -33,8 +33,6 @@ use moodle_exception;
 use moodleform;
 use core_user;
 
-use function get_string;
-
 defined('MOODLE_INTERNAL') || die();
 
 /** @var \core_config $CFG */
@@ -149,6 +147,19 @@ class edit extends moodleform {
 
         $mform->addElement(
             'duration',
+            'reminderdaterelativeenrollmentrecurring',
+            get_string('form_nudge_remindertyperelativedaterecurring', 'local_nudge'),
+            [
+                // Default to days.
+                'defaultunit' => \DAYSECS
+            ]
+        );
+        $mform->setDefault('reminderdaterelativeenrollmentrecurring', 86400);
+        $mform->hideIf('reminderdaterelativeenrollmentrecurring', 'remindertype', 'neq', nudge::REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING);
+        $mform->addHelpButton('reminderdaterelativeenrollmentrecurring', 'form_nudge_remindertyperelativedaterecurring', 'local_nudge');
+
+        $mform->addElement(
+            'duration',
             'reminderdaterelativecourseend',
             get_string('form_nudge_reminderdatecoruseend', 'local_nudge'),
             [
@@ -199,6 +210,9 @@ class edit extends moodleform {
                 break;
             case (nudge::REMINDER_DATE_RELATIVE_ENROLLMENT):
                 $instancedata['remindertypeperiod'] = $data->reminderdaterelativeenrollment;
+                break;
+            case (nudge::REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING):
+                $instancedata['remindertypeperiod'] = $data->reminderdaterelativeenrollmentrecurring;
                 break;
             case (nudge::REMINDER_DATE_RELATIVE_COURSE_END):
                 $instancedata['remindertypeperiod'] = $data->reminderdaterelativecourseend;

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -329,6 +329,24 @@ class edit extends moodleform {
             }
         }
 
+        // Validate it: has no scheduling conflicts with the course's *current* end date.
+        if (
+            !empty($data['remindertype']) &&
+            $data['remindertype'] === nudge::REMINDER_DATE_INPUT_FIXED
+        ) {
+            $targetcourse = \get_course($data['courseid']);
+            $enddate = ((int) $targetcourse->enddate) ?: false;
+            if ($enddate) {
+                if ($data['remindertypefixeddate'] >= $enddate) {
+                    $errors['remindertypefixeddate'] = \get_string(
+                        'validation_nudge_timepastcourseend',
+                        'local_nudge',
+                        \date(nudge::DATE_FORMAT_NICE, $enddate)
+                    );
+                }
+            }
+        }
+
         return $errors;
     }
 

--- a/classes/form/nudge_notification/delete.php
+++ b/classes/form/nudge_notification/delete.php
@@ -24,13 +24,12 @@
 
 namespace local_nudge\form\nudge_notification;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/formslib.php');
+// @codeCoverageIgnoreEnd
 
-/**
- * @codeCoverageIgnore
- */
 class delete extends \moodleform {
     public function definition() {
         $mform = $this->_form;
@@ -43,7 +42,7 @@ class delete extends \moodleform {
             <div class="alert alert-danger">{$deletestring}<div><br/>
         HTML);
 
-        // TODO: Add checkbox here to also delete notification translations that is checked by default.
+        $mform->addElement('static', 'title');
 
         $this->add_action_buttons(true, get_string('delete'));
     }

--- a/classes/form/nudge_notification/edit.php
+++ b/classes/form/nudge_notification/edit.php
@@ -93,7 +93,7 @@ class edit extends moodleform {
             'title',
             get_string('form_notification_title', 'local_nudge')
         );
-        $mform->setType('title', \PARAM_RAW);
+        $mform->setType('title', \PARAM_TEXT);
         $mform->addRule('title', get_string('validation_notification_needtitle', 'local_nudge'), 'required');
 
         $userquery = $DB->get_records_sql(<<<SQL
@@ -170,7 +170,7 @@ class edit extends moodleform {
             $repeatcount,
             [
                 'contentid' => [
-                    'type' => \PARAM_INT
+                    'type' => \PARAM_INT,
                 ],
                 'lang' => [
                     'rule' => 'required'

--- a/classes/local/abstract_nudge_entity.php
+++ b/classes/local/abstract_nudge_entity.php
@@ -132,10 +132,9 @@ abstract class abstract_nudge_entity {
             }
 
             throw new UnexpectedValueException(\sprintf(
-                '%s\'s %s method was passed a property/field that doesn\'t exist on %s. Property name was: %s',
-                __CLASS__,
-                __METHOD__,
-                __CLASS__,
+                '%s\'s __construct method was passed a property/field that doesn\'t exist on %s. Property name was: %s',
+                static::class,
+                static::class,
                 $key
             ));
         }
@@ -151,6 +150,8 @@ abstract class abstract_nudge_entity {
 
     /**
      * Fluent setter.
+     *
+     * @codeCoverageIgnore
      *
      * @return $this
      */

--- a/classes/local/abstract_nudge_entity.php
+++ b/classes/local/abstract_nudge_entity.php
@@ -163,5 +163,5 @@ abstract class abstract_nudge_entity {
      *
      * @return void
      */
-    abstract protected function cast_fields();
+    abstract protected function cast_fields(): void;
 }

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -26,10 +26,12 @@ use moodle_exception;
 use stdClass;
 use moodle_url;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once(__DIR__ . '/../../lib.php');
+// @codeCoverageIgnoreEnd
 
 /**
  * @package     local_nudge\local
@@ -82,7 +84,6 @@ class nudge extends abstract_nudge_entity {
     public const REMINDER_RECIPIENT_BOTH = 'both';
     // END ENUM - REMINDER RECIPIENT    ////////////////////
 
-    /** {@inheritDoc} */
     public const DEFAULTS = [
         'title' => 'Untitled Nudge',
         'isenabled' => 0,
@@ -91,7 +92,7 @@ class nudge extends abstract_nudge_entity {
     ];
 
     /**
-     * {@see nudge::hydrate_notification_template()}
+     * {@see hydrate_notification_template()}
      *
      * @var array<string>
      */
@@ -174,6 +175,8 @@ class nudge extends abstract_nudge_entity {
     public $remindertypeperiod = null;
 
     /**
+     * Returns the notification configured to go to the learners.
+     *
      * @return nudge_notification|null
      */
     public function get_learner_notification() {
@@ -184,6 +187,8 @@ class nudge extends abstract_nudge_entity {
     }
 
     /**
+     * Returns the notification configured to go to a learner's managers.
+     *
      * @return nudge_notification|null
      */
     public function get_manager_notification() {
@@ -194,6 +199,8 @@ class nudge extends abstract_nudge_entity {
     }
 
     /**
+     * Returns the course this nudge is linked to.
+     *
      * @return \core\entity\course|\stdClass
      */
     public function get_course() {
@@ -286,6 +293,10 @@ class nudge extends abstract_nudge_entity {
         }
     }
 
+    /**
+     * Triggers this nudge to cause messages to send.
+     * This doesn't account for timing it merely sends the configured notifications to the configured recipients.
+     *
      * @param \core\entity\user|stdClass $user
      */
     public function trigger($user): void {

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -292,14 +292,12 @@ class nudge extends abstract_nudge_entity {
         switch ($this->reminderrecipient) {
             case (self::REMINDER_RECIPIENT_BOTH):
                 \message_send(nudge_get_email_message($this, $user));
-
                 foreach (nudge_get_managers_for_user($user) as $manager) {
                     if ($manager === null) {
                         continue;
                     }
                     \message_send(nudge_get_email_message($this, $user, $manager));
                 }
-
                 break;
 
             case (self::REMINDER_RECIPIENT_LEARNER):
@@ -313,7 +311,6 @@ class nudge extends abstract_nudge_entity {
                     }
                     \message_send(nudge_get_email_message($this, $user, $manager));
                 }
-
                 break;
             default:
                 // Weird.
@@ -321,7 +318,6 @@ class nudge extends abstract_nudge_entity {
                     'expectedunreachable',
                     'local_nudge'
                 );
-                break;
         }
     }
 

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -40,9 +40,8 @@ require_once(__DIR__ . '/../../lib.php');
 class nudge extends abstract_nudge_entity {
 
     // This is just here since the nudge entity is pretty universal.
-    // It should be in the lib but I don't quite have my head around the entire require || die security stuff yet.
-    // Example: `Monday 17th of June at 11:38am`
-    public const DATE_FORMAT_NICE = 'l jS \of F \a\\t g:ia';
+    // Example: `Monday 17th of June at 11:38am, 2444`
+    public const DATE_FORMAT_NICE = 'l jS \of F \a\\t g:ia, Y';
 
     // BEGIN ENUM - REMINDER DATE    ////////////////////
     /**

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -51,14 +51,19 @@ class nudge extends abstract_nudge_entity {
     public const REMINDER_DATE_INPUT_FIXED = 'fixed';
 
     /**
-     * This Nudge instance's reminder timing is based on the user's date of enrollment.
+     * This Nudge instance's reminder timing is relative to the course's end date.
+     */
+    public const REMINDER_DATE_RELATIVE_COURSE_END = 'courseend';
+
+    /**
+     * This Nudge instance's reminder timing is relative to the user's date of enrollment.
      */
     public const REMINDER_DATE_RELATIVE_ENROLLMENT = 'enrollment';
 
     /**
-     * This Nudge instance's reminder timing is infered from the course's end date.
+     * This Nudge instance's reminder timing recurrs based on the user's date of enrollment.
      */
-    public const REMINDER_DATE_RELATIVE_COURSE_END = 'courseend';
+    public const REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING = 'enrollmentrecurring';
     // END ENUM - REMINDER DATE    ////////////////////
 
     // BEGIN ENUM - REMINDER RECIPIENT    ////////////////////
@@ -155,12 +160,15 @@ class nudge extends abstract_nudge_entity {
      * {@see self::$remindertype} == {@see self::REMINDER_DATE_RELATIVE_COURSE_END}
      * ```
      * OR
-     * the period of time post learner enrollment to repeat nudges if
+     * the period of time post learner enrollment to send nudges
      * ```
      * {@see self::$remindertype} == {@see self::REMINDER_DATE_RELATIVE_ENROLLMENT}.
      * ```
-     *
-     * @todo Validate that the the duration field cannot exceed MYSQL bigint on the form and below constructor.
+     * OR
+     * the period of time post learner enrollment to repeat nudges if
+     * ```
+     * {@see self::$remindertype} == {@see self::REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING}.
+     * ```
      *
      * @var int|null Time in seconds.
      */

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -202,21 +202,56 @@ class nudge extends abstract_nudge_entity {
     }
 
     /**
+     * Returns an array of mixed values to be casted to string an rendered as raw html on the display tables.
+     *
      * @return array<mixed>
      */
     public function get_summary_fields(): array {
+        $learnernotification = $this->get_learner_notification() ?? false;
+        $managernotification = $this->get_manager_notification() ?? false;
+
+        if ($this->reminderrecipient !== self::REMINDER_RECIPIENT_BOTH) {
+            if ($this->reminderrecipient !== self::REMINDER_RECIPIENT_LEARNER) {
+                $learnernotification = false;
+            }
+            if ($this->reminderrecipient !== self::REMINDER_RECIPIENT_MANAGERS) {
+                $managernotification = false;
+            }
+        }
+
         return [
-            $this->title,
-            // TODO: Should this be a link?
-            // TODO: If it has both notifications but the type is still only one -
-            // show only one.
-            $this->get_learner_notification()->title ?? 'None',
-            $this->get_manager_notification()->title ?? 'None',
+            $this->get_nudge_edit_link(),
+            ($learnernotification)
+                ? $learnernotification->get_notification_edit_link()
+                : 'None',
+            ($managernotification)
+                ? $managernotification->get_notification_edit_link()
+                : 'None',
             \ucfirst($this->remindertype)
         ];
     }
 
     /**
+     * Gets a link to edit this nudge
+     *
+     * Note that this is scoped to course so the user may need that capability.
+     *
+     * @return string
+     */
+    public function get_nudge_edit_link(): string {
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        $link = "{$CFG->wwwroot}/local/nudge/edit_nudge.php?id={$this->id}&courseid={$this->courseid}";
+
+        $linktitle = \get_string('nudge_edit_link', 'local_nudge', $this->title);
+
+        $linkhtml = <<<HTML
+            <a href="{$link}">{$linktitle}</a>
+        HTML;
+
+        return $linkhtml;
+    }
 
     /**
      * Notifies both the user who created and last modified this nudge.

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -170,8 +170,7 @@ class nudge extends abstract_nudge_entity {
         if ($this->linkedlearnernotificationid == 0) {
             return null;
         }
-        // TODO: casting.
-        return nudge_notification_db::get_by_id(\intval($this->linkedlearnernotificationid));
+        return nudge_notification_db::get_by_id($this->linkedlearnernotificationid);
     }
 
     /**
@@ -181,8 +180,7 @@ class nudge extends abstract_nudge_entity {
         if ($this->linkedmanagernotificationid == 0) {
             return null;
         }
-        // TODO: casting.
-        return nudge_notification_db::get_by_id(\intval($this->linkedmanagernotificationid));
+        return nudge_notification_db::get_by_id($this->linkedmanagernotificationid);
     }
 
     /**

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -247,8 +247,7 @@ class nudge extends abstract_nudge_entity {
         }
     }
 
-    /** {@inheritDoc} */
-    protected function cast_fields() {
+    protected function cast_fields(): void {
         $this->courseid = (int) $this->courseid;
         $this->linkedlearnernotificationid = (int) $this->linkedlearnernotificationid;
         $this->linkedmanagernotificationid = (int) $this->linkedmanagernotificationid;

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -64,6 +64,21 @@ class nudge_notification extends abstract_nudge_entity {
         return nudge_notification_content_db::get_all_filtered($filter);
     }
 
+    public function get_notification_edit_link(): string {
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        $link = "{$CFG->wwwroot}/local/nudge/edit_notification.php?id={$this->id}";
+
+        $linktitle = get_string('notification_edit_link', 'local_nudge', $this->title);
+
+        $linkhtml = <<<HTML
+            <a href="{$link}">{$linktitle}</a>
+        HTML;
+
+        return $linkhtml;
+    }
+
     /**
      * Returns $this wrapped in a {@link nudge_notification_form_data} with it's linked {@link nudge_notification_content}s.
      *
@@ -87,8 +102,7 @@ class nudge_notification extends abstract_nudge_entity {
         $notificationcount = count($this->get_contents());
         return [
             $this->id,
-            // TODO: Should this be a link?
-            $this->title,
+            $this->get_notification_edit_link(),
             <<<HTML
                 <p class="badge badge-primary">There are {$notificationcount} linked translations</p>
             HTML

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -95,7 +95,7 @@ class nudge_notification extends abstract_nudge_entity {
         ];
     }
 
-    protected function cast_fields() {
+    protected function cast_fields(): void {
         $this->title = (string) $this->title;
         $this->userfromid = (int) $this->userfromid;
     }

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+// phpcs:disable moodle.Commenting
+
 /**
  * @package     local_nudge\local
  * @author      Liam Kearney <liam@sproutlabs.com.au>

--- a/classes/local/nudge_notification_content.php
+++ b/classes/local/nudge_notification_content.php
@@ -74,7 +74,7 @@ class nudge_notification_content extends abstract_nudge_entity {
         return nudge_notification_db::get_by_id(\intval($this->nudgenotificationid));
     }
 
-    protected function cast_fields() {
+    protected function cast_fields(): void {
         $this->nudgenotificationid = (int) $this->nudgenotificationid;
         $this->lang = (string) $this->lang;
         $this->subject = (string) $this->subject;

--- a/classes/local/nudge_notification_content.php
+++ b/classes/local/nudge_notification_content.php
@@ -68,10 +68,10 @@ class nudge_notification_content extends abstract_nudge_entity {
      */
     public function get_notification() {
         // Default notification.
-        if (\intval($this->nudgenotificationid) === 0) {
+        if ($this->nudgenotificationid === 0) {
             return null;
         }
-        return nudge_notification_db::get_by_id(\intval($this->nudgenotificationid));
+        return nudge_notification_db::get_by_id($this->nudgenotificationid);
     }
 
     protected function cast_fields(): void {

--- a/classes/local/nudge_user.php
+++ b/classes/local/nudge_user.php
@@ -45,8 +45,9 @@ class nudge_user extends abstract_nudge_entity {
      */
     public $recurrancetime = null;
 
-    protected function cast_fields() {
+    protected function cast_fields(): void {
         $this->userid = (int) $this->userid;
         $this->nudgeid = (int) $this->nudgeid;
+        $this->recurrancetime = (int) $this->recurrancetime;
     }
 }

--- a/classes/task/nudge_task.php
+++ b/classes/task/nudge_task.php
@@ -29,22 +29,25 @@ use local_nudge\local\nudge_user;
 
 use function nudge_mockable_time as time;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
 
 /** @var \core_config $CFG */
 global $CFG;
 require_once($CFG->libdir . '/completionlib.php');;
 require_once(__DIR__ . '/../../lib.php');
+// @codeCoverageIgnoreEnd
 
 /**
+ * This task handles deciding what instances of nudge to call {@see nudge::trigger()} on and for what users.
+ *
+ * The {@see nudge::trigger()} method actually sends the emails using various function in lib to template them.
+ *
  * @package     local_nudge\task
  * @author      Liam Kearney <liam@sproutlabs.com.au>
  * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
  * @license     http://www.gnu.org/copyleft/gpl.html
  * @license     GNU GPL v3 or later
- *
- * @todo Allthough nudge has a really nice DML thanks to a quick almost copy n paste of Catalyst's auth_outage
- * it might be a bit too expensive to use it during the cron so a switch to SQL here only might be a good idea.
  *
  * This is a very pref expensive plugin so a seperate cron worker for this task
  * should be recommended in the readme for serious use of the plugin.
@@ -220,7 +223,7 @@ class nudge_task extends scheduled_task {
     }
 
     /**
-     * Sends emails for incomplete users in an instance of {@see nudge}.
+     * Sends emails for all incomplete users in an instance of {@see nudge}.
      *
      * @param nudge $nudge
      * @return void
@@ -267,8 +270,6 @@ class nudge_task extends scheduled_task {
      *
      * If the user has multiple enrollment instances it picks the enrollment instance with the lowest timestarted
      * AKA the enrollment instance which first introduced the user to the course.
-     *
-     * @todo There seems to be a bug with something related in get_field_sql. works for now.
      *
      * @param int $userid
      * @param int $courseid

--- a/db/messages.php
+++ b/db/messages.php
@@ -41,5 +41,11 @@ $messageproviders = [
             'email' => \MESSAGE_FORCED + \MESSAGE_DEFAULT_LOGGEDOFF + \MESSAGE_DEFAULT_LOGGEDIN,
             'popup' => \MESSAGE_DISALLOWED,
         ]
+    ],
+    'owneremail' => [
+        'defaults' => [
+            'email' => \MESSAGE_FORCED + \MESSAGE_DEFAULT_LOGGEDOFF + \MESSAGE_DEFAULT_LOGGEDIN,
+            'popup' => \MESSAGE_DISALLOWED,
+        ]
     ]
 ];

--- a/delete_notification.php
+++ b/delete_notification.php
@@ -30,8 +30,10 @@
 use local_nudge\dml\nudge_notification_db;
 use local_nudge\form\nudge_notification\delete;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+// @codeCoverageIgnoreEnd
 
 \admin_externalpage_setup('configurenudgenotifications');
 

--- a/delete_notification.php
+++ b/delete_notification.php
@@ -55,6 +55,7 @@ if ($nudgenotification === null) {
 
 $idholder = new stdClass();
 $idholder->id = $nudgenotification->id;
+$idholder->title = $nudgenotification->title;
 
 $mform->set_data($idholder);
 

--- a/delete_nudge.php
+++ b/delete_nudge.php
@@ -51,14 +51,15 @@ if ($mform->is_cancelled()) {
     \redirect($manageurl);
 }
 
-$nudgenotification = nudge_db::get_by_id($id);
-if ($nudgenotification === null) {
-    throw new \invalid_parameter_exception(sprintf('Nudge Notification with id: %s was not found.'));
+$nudge = nudge_db::get_by_id($id);
+if ($nudge === null) {
+    throw new \invalid_parameter_exception(sprintf('Nudge with id: %s was not found.'));
 }
 
 $idholder = new stdClass();
-$idholder->id = $nudgenotification->id;
+$idholder->id = $nudge->id;
 $idholder->courseid = $courseid;
+$idholder->title = $nudge->title;
 
 $mform->set_data($idholder);
 

--- a/delete_nudge.php
+++ b/delete_nudge.php
@@ -30,8 +30,10 @@
 use local_nudge\dml\nudge_db;
 use local_nudge\form\nudge\delete;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+// @codeCoverageIgnoreEnd
 
 $id = \required_param('id', \PARAM_INT);
 $courseid = \optional_param('courseid', null, \PARAM_INT);

--- a/docs/dev/05-file-security.md
+++ b/docs/dev/05-file-security.md
@@ -7,6 +7,15 @@ If a file has `REQUIRED` you **MUST** take action to prevent unwanted data leaka
 
 If a file has `TODO` or is not present on this list please raise a GH issue.
 
+> Note that Nudge ships with some simple checks to help establish if *some* of these files are secure.
+> You can access these at:
+```php
+$url = "{$CFG->wwwroot}/report/security/index.php";
+```
+or:
+`https://subdomain.atdomain.tld/report/security/index.php`
+
+
 | File                                                                                                                             | Security Measure | Action Required                                             |
 | :------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------- |
 | [.github/workflows/moodle-ci.yml](../../.github/workflows/moodle-ci.yml)                                                         | REQUIRED         | Deny dotfiles                                               |
@@ -35,7 +44,7 @@ If a file has `TODO` or is not present on this list please raise a GH issue.
 | [classes/task/nudge_task.php](../../classes/task/nudge_task.php)                                                                 | NONE             | Optional: Additionally covered by denying classes directory |
 | [composer.json](../../composer.json)                                                                                             | REQUIRED         | Deny composer.json files                                    |
 | [db/access.php](../../db/access.php)                                                                                             | NONE             | None                                                        |
-| [db/install.xml](../../db/install.xml)                                                                                           | REQUIRED         | Deny .xml files                                             |
+| [db/install.xml](../../db/install.xml)                                                                                           | REQUIRED         | Deny install.xml files                                      |
 | [db/messages.php](../../db/messages.php)                                                                                         | NONE             | None                                                        |
 | [db/tasks.php](../../db/tasks.php)                                                                                               | NONE             | None                                                        |
 | [delete_notification.php](../../delete_notification.php)                                                                         | PUBLIC           | None                                                        |

--- a/edit_notification.php
+++ b/edit_notification.php
@@ -33,8 +33,10 @@ use local_nudge\dml\nudge_notification_db;
 use local_nudge\form\nudge_notification\edit;
 use local_nudge\local\nudge_notification;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+// @codeCoverageIgnoreEnd
 
 \admin_externalpage_setup('configurenudgenotifications');
 

--- a/edit_notification.php
+++ b/edit_notification.php
@@ -27,6 +27,7 @@
  * @var \core_renderer      $OUTPUT
  */
 
+use core\output\notification;
 use local_nudge\dml\nudge_notification_content_db;
 use local_nudge\dml\nudge_notification_db;
 use local_nudge\form\nudge_notification\edit;
@@ -49,7 +50,12 @@ if ($mform->is_cancelled()) {
     \redirect($manageurl);
 } else if ($editdata = $mform->get_data()) {
     if ($editdata === null) {
-        \redirect($manageurl);
+        \redirect(
+            $manageurl,
+            'Unable to save notification',
+            null,
+            notification::NOTIFY_ERROR
+        );
     }
 
     $notificationid = nudge_notification_db::save($editdata->notification);
@@ -59,7 +65,12 @@ if ($mform->is_cancelled()) {
         nudge_notification_content_db::save($notificationcontent);
     }
 
-    \redirect($manageurl);
+    \redirect(
+        $manageurl,
+        "Edited notification '{$notification->title}' successfully",
+        null,
+        notification::NOTIFY_SUCCESS
+    );
 }
 
 if ($notificationid === 0) {

--- a/edit_notification.php
+++ b/edit_notification.php
@@ -58,7 +58,8 @@ if ($mform->is_cancelled()) {
         );
     }
 
-    $notificationid = nudge_notification_db::save($editdata->notification);
+    $notification = nudge_notification_db::create_or_refresh($editdata->notification);
+    $notificationid = $notification->id;
 
     foreach ($editdata->notificationcontents as $notificationcontent) {
         $notificationcontent->nudgenotificationid = $notificationid;

--- a/edit_nudge.php
+++ b/edit_nudge.php
@@ -27,6 +27,7 @@
  * @var \core_renderer      $OUTPUT
  */
 
+use core\output\notification;
 use local_nudge\dml\nudge_db;
 use local_nudge\form\nudge\edit;
 use local_nudge\local\nudge;
@@ -51,11 +52,21 @@ if ($mform->is_cancelled()) {
     \redirect($manageurl);
 } else if ($editdata = $mform->get_data()) {
     if ($editdata === null) {
-        \redirect($manageurl);
+        \redirect(
+            $manageurl,
+            'Unable to save nudge',
+            null,
+            notification::NOTIFY_ERROR
+        );
     }
 
-    nudge_db::save($editdata);
-    \redirect($manageurl);
+    $nudge = nudge_db::create_or_refresh($editdata);
+    \redirect(
+        $manageurl,
+        "Edited nudge '{$nudge->title}' successfully",
+        null,
+        notification::NOTIFY_SUCCESS
+    );
 }
 
 // We do this so cancelations of unsaved nudge forms know which course to return to.

--- a/edit_nudge.php
+++ b/edit_nudge.php
@@ -32,8 +32,10 @@ use local_nudge\dml\nudge_db;
 use local_nudge\form\nudge\edit;
 use local_nudge\local\nudge;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+// @codeCoverageIgnoreEnd
 
 $nudgeid = \required_param('id', \PARAM_INT);
 $courseid = \required_param('courseid', \PARAM_INT);

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -28,99 +28,112 @@
 defined('MOODLE_INTERNAL') || die();
 
 // META
-$string['pluginname']                               =       'Nudge';
-$string['crontask']                                 =       'Nudge Cron Task';
-$string['configurenudges']                          =       'Configure Nudge Reminders';
-$string['configurenudgenotifications']              =       'Configure Site Nudge Notifications';
+$string['pluginname']                                               =       'Nudge';
+$string['crontask']                                                 =       'Nudge Cron Task';
+$string['configurenudges']                                          =       'Configure Nudge Reminders';
+$string['configurenudgenotifications']                              =       'Configure Site Nudge Notifications';
+
+
+// ---------------------------------------
+//              DISPLAY
+// ---------------------------------------
+// This is here in case you wanted to clarify and prefix with `Edit: {$a}` (a is title) etc.
+$string['notification_edit_link']                                   =       '{$a}';
+$string['nudge_edit_link']                                          =       '{$a}';
 
 
 // ---------------------------------------
 //             MANAGE PAGES
 // ---------------------------------------
 // Nudge
-$string['manage_nudge_add']                         =       'Add a Nudge';
-$string['manage_nudge_notificationslink']           =       'Manage Notifications';
+$string['manage_nudge_add']                                         =       'Add a Nudge';
+$string['manage_nudge_notificationslink']                           =       'Manage Notifications';
 
 // Nudge Notification
-$string['manage_notification_add']                  =       'Add a Nudge Notification';
+$string['manage_notification_add']                                  =       'Add a Nudge Notification';
 
 
 // ---------------------------------------
 //              EDIT FORMS
 // ---------------------------------------
 // Universal
-$string['form_metahdr']                             =       'Metadata';
-$string['form_noyetset']                            =       'Not yet set.';
+$string['form_metahdr']                                             =       'Metadata';
+$string['form_noyetset']                                            =       'Not yet set.';
 
 // Nudge
-$string['form_nudge_title']                         =       'Title';
+$string['form_nudge_title']                                         =       'Title';
 
-$string['form_nudge_isenabled']                     =       'Is Enabled?';
-$string['form_nudge_isenabled_help']                =       <<<EOF
+$string['form_nudge_isenabled']                                     =       'Is Enabled?';
+$string['form_nudge_isenabled_help']                                =       <<<HTML
 <p>You can enable or disable this notification here.</p>
 <p>A notification may disable itself once certain conditions have been met:</p>
 <ol>
-    <li>Relative date: When the course has ended.</li>
+    <li>Enrollment date: When the course has ended.</li>
     <li>Course end date: When the notification prior to course end has been sent.</li>
     <li>Fixed date: When the notification has been sent.</li>
 </ol>
-EOF;
+HTML;
 
-$string['form_nudge_reminderrecipient']             =       'Reminder Recipient';
-$string['form_nudge_reminderrecipient_help']        =       <<<EOF
+$string['form_nudge_reminderrecipient']                             =       'Reminder Recipient';
+$string['form_nudge_reminderrecipient_help']                        =       <<<EOF
 Select recipients of this nudge reminder.
 EOF;
 
-$string['form_nudge_learnernotification']           =       'Notification for the Learner';
-$string['form_nudge_learnernotification_help']      =       <<<EOF
+$string['form_nudge_learnernotification']                           =       'Notification for the Learner';
+$string['form_nudge_learnernotification_help']                      =       <<<EOF
 TODO
 EOF;
 
-$string['form_nudge_managernotification']           =       'Notification for the Managers';
-$string['form_nudge_managernotification_help']      =       <<<EOF
+$string['form_nudge_managernotification']                           =       'Notification for the Managers';
+$string['form_nudge_managernotification_help']                      =       <<<EOF
 TODO
 EOF;
 
-$string['form_nudge_remindertype']                  =       'Reminder Timing';
-$string['form_nudge_remindertype_help']             =       <<<EOF
+$string['form_nudge_remindertype']                                  =       'Reminder Timing';
+$string['form_nudge_remindertype_help']                             =       <<<EOF
 Select a timing method to base sent nudges on.
 EOF;
 
-$string['form_nudge_remindertypefixeddate']         =       'Choose a fixed reminder date';
-$string['form_nudge_remindertypefixeddate_help']    =       <<<EOF
+$string['form_nudge_remindertypefixeddate']                         =       'Choose a fixed reminder date';
+$string['form_nudge_remindertypefixeddate_help']                    =       <<<EOF
 TODO
 EOF;
 
-$string['form_nudge_remindertyperelativedate']      =       'Repeat every x after a user\'s enrollment';
-$string['form_nudge_remindertyperelativedate_help'] =       <<<EOF
+$string['form_nudge_remindertyperelativedate']                      =       'Remind x after the user\s enrollment';
+$string['form_nudge_remindertyperelativedate_help']                 =       <<<EOF
+TODO You can setup this notification to remind users relative to their enrollment date.
+EOF;
+
+$string['form_nudge_remindertyperelativedaterecurring']             =       'Repeat every x after a user\'s enrollment';
+$string['form_nudge_remindertyperelativedaterecurring_help']        =       <<<EOF
 TODO make this minium 5 minutes to make it align with cron
 EOF;
 
-$string['form_nudge_reminderdatecoruseend']         =       'Reminder x before course ends';
-$string['form_nudge_reminderdatecoruseend_help']    =       <<<EOF
+$string['form_nudge_reminderdatecoruseend']                         =       'Reminder x before course ends';
+$string['form_nudge_reminderdatecoruseend_help']                    =       <<<EOF
 TODO
 EOF;
 
-$string['form_nudge_deleteconfirm']                 =       'Are you sure you want delete this nudge?';
+$string['form_nudge_deleteconfirm']                                 =       'Are you sure you want delete this nudge?';
 
 // Notification
-$string['form_notification_title']                  =       'Add a title';
+$string['form_notification_title']                                  =       'Add a title';
 
-$string['form_notification_userfrom']               =       'Select a user as the sender for this email';
+$string['form_notification_userfrom']                               =       'Select a user as the sender for this email';
 
-$string['form_notification_templatevar_title']      =       'Template Infomation';
-$string['form_notification_templatevar_help']       =       'You can use the following properties in a translation:';
+$string['form_notification_templatevar_title']                      =       'Template Infomation';
+$string['form_notification_templatevar_help']                       =       'You can use the following properties in a translation:';
 
-$string['form_notification_translation_header']     =       'Unsaved Translation';
-$string['form_notification_translation_template']   =       'Translation - {$a->language}: {$a->subject}';
+$string['form_notification_translation_header']                     =       'Unsaved Translation';
+$string['form_notification_translation_template']                   =       'Translation - {$a->language}: {$a->subject}';
 
-$string['form_notification_selectlang']             =       'Select a language';
-$string['form_notification_addsubject']             =       'Add a subject';
-$string['form_notification_addbody']                =       'Add a body';
+$string['form_notification_selectlang']                             =       'Select a language';
+$string['form_notification_addsubject']                             =       'Add a subject';
+$string['form_notification_addbody']                                =       'Add a body';
 
-$string['form_notification_addprompt']              =       'Add {no} more translation{possible_s}';
+$string['form_notification_addprompt']                              =       'Add {no} more translation{possible_s}';
 
-$string['form_notification_deleteconfirm']                 =       'Are you sure you want delete this notification?';
+$string['form_notification_deleteconfirm']                          =       'Are you sure you want delete this notification?';
 
 
 // ---------------------------------------
@@ -128,95 +141,126 @@ $string['form_notification_deleteconfirm']                 =       'Are you sure
 // See: local/nudge/lib.php::nudge_scaffold_select_from_constants()
 // ---------------------------------------
 // Reminder Date
-$string['reminderdateinputfixed']                   =       'Reminder Date Input Fixed';
-$string['reminderdaterelativeenrollment']           =       'Reminder Date Relative Enrollment';
-$string['reminderdaterelativecourseend']            =       'Reminder Date Relative Course End';
+$string['reminderdateinputfixed']                                   =       'Reminder Date Input Fixed';
+$string['reminderdaterelativeenrollment']                           =       'Reminder Date Relative Enrollment';
+$string['reminderdaterelativeenrollmentrecurring']                  =       'Reminder Date Relative Enrollment Recurring';
+$string['reminderdaterelativecourseend']                            =       'Reminder Date Relative Course End';
 
 // Reminder Recipient
-$string['reminderrecipientlearner']                 =       'The Learner';
-$string['reminderrecipientmanagers']                =       'The Learner\'s Managers';
-$string['reminderrecipientboth']                    =       'Both the Learner and their Managers';
+$string['reminderrecipientlearner']                                 =       'The Learner';
+$string['reminderrecipientmanagers']                                =       'The Learner\'s Managers';
+$string['reminderrecipientboth']                                    =       'Both the Learner and their Managers';
 
 
 // ---------------------------------------
 //                  ADMIN
 // ---------------------------------------
 // General
-$string['configurenudge']                           =       'Configure Nudge';
-$string['manage_settings']                          =       'Configure Nudge Settings';
+$string['configurenudge']                                           =       'Configure Nudge';
+$string['manage_settings']                                          =       'Configure Nudge Settings';
 
 // Managers settings
-$string['admin_manager_heading']                    =       'Manager Settings';
-$string['admin_manager_heading_desc']               =       <<<EOF
+$string['admin_manager_heading']                                    =       'Manager Settings';
+$string['admin_manager_heading_desc']                               =       <<<EOF
 These are just for emulation on MOODLE, Totara already has a system for this.
 EOF;
 
-$string['admin_custom_managerresolution']           =       'Custom manager resolution enabled';
-$string['admin_custom_managerresolution_desc']      =       <<<EOF
+$string['admin_custom_managerresolution']                           =       'Custom manager resolution enabled';
+$string['admin_custom_managerresolution_desc']                      =       <<<EOF
 If this is enabled the below two fields will be used for custom manager resolution.
 In Totara this is generally not a good idea however this is <em><strong>needed</strong> for MOODLE solutions</em>.
 EOF;
 
-$string['admin_manager_matchwith_field']            =       'Manager match with field';
-$string['admin_manager_matchwith_field_desc']       =       <<<EOF
+$string['admin_manager_matchwith_field']                            =       'Manager match with field';
+$string['admin_manager_matchwith_field_desc']                       =       <<<EOF
 This field will be used to match managers with.
 This will be the field on a user's profile that matches the match on field on the Manager's profile
 EOF;
 
-$string['admin_manager_matchon_field']              =       'Manager match on field';
-$string['admin_manager_matchon_field_desc']         =       <<<EOF
+$string['admin_manager_matchon_field']                              =       'Manager match on field';
+$string['admin_manager_matchon_field_desc']                         =       <<<EOF
 This field will be used to match managers on.
 This is the "unique" identifier for a manager
 EOF;
 
 // UX Settings
-$string['admin_ux_heading']                         =       'User Experience Settings';
-$string['admin_ux_heading_desc']                    =       <<<EOF
+$string['admin_ux_heading']                                         =       'User Experience Settings';
+$string['admin_ux_heading_desc']                                    =       <<<EOF
 You can configure some settings to make Nudge easier to work with here.
 EOF;
 
-$string['admin_ux_addtranslationcount']             =       'Notification add count';
-$string['admin_ux_addtranslationcount_desc']        =       <<<EOF
+$string['admin_ux_addtranslationcount']                             =       'Notification add count';
+$string['admin_ux_addtranslationcount_desc']                        =       <<<EOF
 The amount of translations to add each time when creating a Nudge Notification.
 EOF;
 
-$string['admin_ux_enddate']                       =       'Start date';
-$string['admin_ux_enddate_desc']                  =       <<<EOF
+$string['admin_ux_enddate']                                         =       'Start date';
+$string['admin_ux_enddate_desc']                                    =       <<<EOF
 You can select a start date here to limit date pickers.
 EOF;
 
 // Performance Settings
-$string['admin_performance_heading']                =       'Performance Settings';
-$string['admin_performance_heading_desc']           =       <<<EOF
+$string['admin_performance_heading']                                =       'Performance Settings';
+$string['admin_performance_heading_desc']                           =       <<<EOF
 You can make some performance tradeoffs here.
 EOF;
 
 // TODO: Implement me
-$string['admin_performance_nolog']                  =       'Performance mode';
-$string['admin_performance_nolog_desc']             =       <<<EOF
+$string['admin_performance_nolog']                                  =       'Performance mode';
+$string['admin_performance_nolog_desc']                             =       <<<EOF
 Enabling this will disable the creation of events, reducing queries required on the cron worker.
 However this is usually a bad idea since it makes it almost impossible to track changes.
 EOF;
-
-// TODO: convert some of the DML called from the cron to SQL.
 
 
 // ---------------------------------------
 //                 ERRORS
 // ---------------------------------------
-$string['expectedunreachable']                      =       'Expected unreachable, It\'s possible a malformed database value was encountered.';
-$string['nudgenotificationdoesntexist']             =       'Can\'t find Nudge Notification with the ID: {$a}';
-$string['nudgedoesntexist']                         =       'Can\'t find Nudge with the ID: {$a}';
-$string['cantmatchmanager']                         =       'The option to match on manager custom fields is on but no field is selected';
+$string['expectedunreachable']                                      =       'Expected unreachable, It\'s possible a malformed database value was encountered.';
+$string['nudgenotificationdoesntexist']                             =       'Can\'t find Nudge Notification with the ID: {$a}';
+$string['nudgedoesntexist']                                         =       'Can\'t find Nudge with the ID: {$a}';
+$string['cantmatchmanager']                                         =       'The option to match on manager custom fields is on but no field is selected';
+
 
 // ---------------------------------------
 //               VALIDATION
 // ---------------------------------------
 // Nudge
-$string['validation_nudge_neednotifications']       =       'The selected recipient type was: "{$a}" but there wasn\'t wasn\'t enough notifications to cover the recipients.';
-$string['validation_nudge_needtitle']               =       'You need to supply a title for identification';
+$string['validation_nudge_neednotifications']                       =       'The selected recipient type was: "{$a}" but there wasn\'t wasn\'t enough notifications to cover the recipients.';
+$string['validation_nudge_needtitle']                               =       'You need to supply a title for identification';
+$string['validation_nudge_timepastcourseend']                       =       'The reminder will occur past the courses end date: "{$a}". Please update the value to something that will occur prior';
+$string['validation_nudge_needfixeddate']                           =       'You must supply a fixed date for this type of reminder';
 
 // Nudge Notification
-$string['validation_notification_needsender']       =       'You must set a sender';
-$string['validation_notification_needtitle']        =       'Title is required for usability';
-$string['validation_notification_duplicatelangs']   =       'Ensure there is only one translation for each language';
+$string['validation_notification_needsender']                       =       'You must set a sender';
+$string['validation_notification_needtitle']                        =       'Title is required for usability';
+$string['validation_notification_duplicatelangs']                   =       'Ensure there is only one translation for each language';
+
+
+// ---------------------------------------
+//               MESSAGES
+// ---------------------------------------
+$string['messageprovider:learneremail']                             =       'Nudge message to learners';
+$string['messageprovider:manageremail']                             =       'Nudge message to a learner\'s managers';
+$string['messageprovider:owneremail']                               =       'Nudge message to the last editor and creator';
+
+
+// ---------------------------------------
+//               EXCEPTIONS
+// ---------------------------------------
+$string['nudge_exception_unlinked_notification_subject']            =       '{$a} - Exception for a nudge you manage';
+$string['nudge_exception_unlinked_notification_body']               =       <<<'HTML'
+<h5>Hi There,</h5>
+<p>This notification comes from <code>{$a->sitefullname}</code></p>
+<p>You are receiving this notification because a nudge instance you manage has been disabled.</p>
+<p>By manage it could mean either you were the last person to edit or the person who created:
+    <code>{$a->nudgetitle}</code>.</p>
+<br />
+<p>The notification with the title <code>{$a->notificationtitle}</code> has been deleted.</p>
+<p>The nudge instance with the title <code>{$a->nudgetitle}</code> has been disabled because of this.</p>
+<p>It is <strong>crucial</strong> that you logon and setup a new notification if you wish for notifications to continue
+    sending</p>
+<p><em><strong>NOTE:</strong> if you receive two of these messages for the same nudge its likely that the notification
+        was in use
+        as both the learner and manager notification.</em></p>
+HTML;

--- a/lib.php
+++ b/lib.php
@@ -32,6 +32,7 @@ use local_nudge\check\directory\dotfolders_disallowed;
 use local_nudge\check\directory\installxml_disallowed;
 use local_nudge\check\directory\markdown_disallowed;
 use local_nudge\check\directory\tests_disallowed;
+use local_nudge\dml\nudge_db;
 use local_nudge\local\nudge;
 use local_nudge\local\nudge_notification;
 
@@ -95,6 +96,30 @@ function local_nudge_security_checks(): array {
         new classes_disallowed(),
         new tests_disallowed(),
     ];
+}
+
+// TODO: pre_user_delete for nudge_user.
+
+/**
+ * Removes {@see nudge}s attached to a course prior to deletion.
+ *
+ * @access private - Is public but not part of module's API.
+ *
+ * @param stdClass|\core\entity\course $course
+ * @return void
+ */
+function local_nudge_pre_course_delete($course) {
+    /** @var \core_renderer $OUTPUT */
+    /** @var \moodle_database $DB */
+    global $OUTPUT, $DB;
+
+    $count = $DB->count_records(nudge_db::$table, ['courseid' => $course->id]);
+
+    nudge_db::delete_all([
+        'courseid' => $course->id
+    ]);
+
+    echo $OUTPUT->notification("Deleted - {$count} attached Nudges", 'notifysuccess');
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -26,6 +26,12 @@
  */
 
 use core\message\message;
+use local_nudge\check\directory\classes_disallowed;
+use local_nudge\check\directory\dotfiles_disallowed;
+use local_nudge\check\directory\dotfolders_disallowed;
+use local_nudge\check\directory\installxml_disallowed;
+use local_nudge\check\directory\markdown_disallowed;
+use local_nudge\check\directory\tests_disallowed;
 use local_nudge\local\nudge;
 use local_nudge\local\nudge_notification;
 
@@ -69,6 +75,26 @@ function local_nudge_extend_navigation_course(
         null,
         new \pix_icon('i/settings', '')
     );
+}
+
+/**
+ * Returns a few security checks that get added to `/report/security/index.php`.
+ *
+ * Totara doesn't allow extending this so don't expect to find it there.
+ *
+ * @access private - Is public but not part of module's API.
+ *
+ * @return array
+ */
+function local_nudge_security_checks(): array {
+    return [
+        new installxml_disallowed(),
+        new dotfolders_disallowed(),
+        new dotfiles_disallowed(),
+        new markdown_disallowed(),
+        new classes_disallowed(),
+        new tests_disallowed(),
+    ];
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -36,17 +36,15 @@ use local_nudge\dml\nudge_db;
 use local_nudge\local\nudge;
 use local_nudge\local\nudge_notification;
 
+// @codeCoverageIgnoreStart
 defined('MOODLE_INTERNAL') || die();
-
-/** @var \core_config $CFG */
-global $CFG;
-
 require_once($CFG->dirroot . '/user/profile/lib.php');
+// @codeCoverageIgnoreEnd
 
 /**
  * Adds a link to manage Nudge instances for this course.
  *
- * @access public
+ * @access private - Is public but not part of module's API.
  *
  * @codeCoverageIgnore Not really logical - Maybe a functional test to check capabilities.
  *
@@ -335,6 +333,8 @@ function nudge_get_managers_for_user($user): array {
  *
  * @access private This is public but its preferable that you use the wrapper function {@see nudge_get_managers_for_user}.
  *
+ * @codeCoverageIgnore We don't run CI with Totara. This one is tested via screams :)
+ *
  * @param \core\entity\user|stdClass $user
  * @return array<\core\entity\user|stdClass>
  */
@@ -384,10 +384,13 @@ function nudge_moodle_get_manager_for_user($user): ?stdClass {
             '*',
             IGNORE_MULTIPLE
         );
+    // phpcs:ignore
+    // @codeCoverageIgnoreStart
     } catch (dml_exception $e) {
         // TODO: Log failed to find manager.
         return null;
     }
+    // @codeCoverageIgnoreEnd
 
     // Null if there is no manager.
     return $manager ?: null;

--- a/lib.php
+++ b/lib.php
@@ -277,6 +277,26 @@ function nudge_hydrate_notification_template(
 }
 
 /**
+ * Return current Unix timestamp, {@see time()} but mockable for tests.
+ *
+ * @access public
+ *
+ * @codeCoverageIgnore
+ *
+ * @return int
+ */
+function nudge_mockable_time(): int {
+    /** @var \core_config $CFG */
+    global $CFG;
+
+    if (!isset($CFG->nudgemocktime)) {
+        return time();
+    } else {
+        return $CFG->nudgemocktime;
+    }
+}
+
+/**
  * Gets a list of managers for a user. This calls the correct function based on the custommangerresolution setting.
  *
  * @access public
@@ -371,20 +391,4 @@ function nudge_moodle_get_manager_for_user($user): ?stdClass {
 
     // Null if there is no manager.
     return $manager ?: null;
-}
-
-/**
- * Return current Unix timestamp, {@see time()} but mockable for tests.
- *
- * @return int
- */
-function nudge_mockable_time(): int {
-    /** @var \core_config $CFG */
-    global $CFG;
-
-    if (!isset($CFG->nudgemocktime)) {
-        return time();
-    } else {
-        return $CFG->nudgemocktime;
-    }
 }

--- a/lib.php
+++ b/lib.php
@@ -127,6 +127,8 @@ function local_nudge_pre_course_delete($course) {
  *
  * @access public
  *
+ * @throws ReflectionException Class doesn't exist for reflection
+ *
  * @param class-string $class Class to lookup consts on via reflection
  * @param string $filter Filter string the constant group of enums contain.
  *
@@ -136,11 +138,11 @@ function nudge_scaffold_select_from_constants($class, $filter): array {
     $rclass = new \ReflectionClass($class);
     $constants = $rclass->getConstants();
 
-    // Filter for constants containing: `REMINDER_DATE`
-    $constants = \array_filter($constants, function ($value, $name) use ($filter) {
+    // Filter for constants by prefix.
+    $constants = \array_filter($constants, function ($name) use ($filter) {
         $match = (\strpos($name, $filter) !== false);
         return $match;
-    }, \ARRAY_FILTER_USE_BOTH);
+    }, \ARRAY_FILTER_USE_KEY);
 
     // Convert constants to a sane reference to language strings.
     $constantfields = [];

--- a/manage_notifications.php
+++ b/manage_notifications.php
@@ -31,8 +31,10 @@
 
 use local_nudge\dml\nudge_notification_db;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+// @codeCoverageIgnoreEnd
 
 // Require a login for this course for the system.
 \admin_externalpage_setup("configurenudgenotifications");

--- a/manage_nudges.php
+++ b/manage_nudges.php
@@ -31,9 +31,11 @@
 
 use local_nudge\dml\nudge_db;
 
+// @codeCoverageIgnoreStart
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 require_once($CFG->libdir . '/tablelib.php');
+// @codeCoverageIgnoreEnd
 
 $courseid = \required_param('courseid', \PARAM_INT);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -42,7 +42,13 @@ parameters:
     #             'popup': int
     #         }
     #     }
+    #     'owneremail': array{
+    #         'defaults': array{
+    #             'email': int,
+    #             'popup': int
+    #         }
+    #     }
     # }
-    NudgeMessageProviders: "array{'learneremail': array{'defaults': array{'email': int,'popup': int}},'manageremail': array{'defaults': array{'email': int,'popup': int}}}"
+    NudgeMessageProviders: "array{'learneremail': array{'defaults': array{'email': int,'popup': int}},'manageremail': array{'defaults': array{'email': int,'popup': int}}, 'owneremail': array{'defaults': array{'email': int,'popup': int}}}"
   universalObjectCratesClasses:
     - core\message\message

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,3 +15,13 @@ function tt() {
     fi
 }
 ```
+
+and for running without overwritting coverage:
+
+```SHELL
+function xx() {
+    clear;
+    echo vendor/bin/phpunit -c local/nudge/tests/phpunit.xml --no-coverage --color --filter $1;
+    vendor/bin/phpunit -c local/nudge/tests/phpunit.xml --no-coverage --color --filter $1
+}
+```

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -3,30 +3,57 @@
 <!-- TODO: https://docs.moodle.org/dev/Writing_PHPUnit_tests#Generating_include_and_exclude_configuration -->
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../lib/phpunit/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="../../../lib/phpunit/phpunit.xsd"
         bootstrap="../../../lib/phpunit/bootstrap.php"
+
+        defaultTestSuite="local_nudge_testsuite"
+
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        processIsolation="false"
+
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
-        processIsolation="false"
-        backupGlobals="false"
-        backupStaticAttributes="false"
+
+        testdox="true"
+        colors="true"
+
         stopOnError="false"
+        stopOnWarning="false"
         stopOnFailure="false"
         stopOnIncomplete="false"
         stopOnSkipped="false"
-        testdox="true"
->
+        stopOnRisky="false"
+        stopOnDefect="false"
 
+        failOnRisky="false"
+        failOnWarning="false"
+>
     <testsuites>
         <testsuite name="local_nudge_testsuite">
             <directory suffix="_test.php">./</directory>
         </testsuite>
+        <testsuite name="local_nudge_benchsuite">
+            <directory suffix="_bench.php">./</directory>
+        </testsuite>
     </testsuites>
-
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">../../classes</directory>
+            <directory suffix=".php">./../classes</directory>
+            <file>./../lib.php</file>
         </whitelist>
     </filter>
+    <logging>
+        <log
+            showUncoveredFiles="true"
+            type="coverage-text"
+            target="php://stdout"
+        />
+        <log
+            showUncoveredFiles="true"
+            type="coverage-html"
+            target="./.phpunit.result"
+        />
+    </logging>
 </phpunit>

--- a/tests/serve-coverage.sh
+++ b/tests/serve-coverage.sh
@@ -1,0 +1,2 @@
+python3 -m http.server
+

--- a/tests/testclasses/dml/abstract_nudge_db_test.php
+++ b/tests/testclasses/dml/abstract_nudge_db_test.php
@@ -1,0 +1,450 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Squiz.PHP.CommentedOutCode
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @package     local_nudge\tests\dml
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\dml;
+
+use advanced_testcase;
+use coding_exception;
+use local_nudge\dml\nudge_db;
+use local_nudge\dml\nudge_notification_content_db;
+use local_nudge\dml\nudge_notification_db;
+use local_nudge\local\nudge;
+use local_nudge\local\nudge_notification;
+use local_nudge\local\nudge_notification_content;
+
+/**
+ * @coversDefaultClass \local_nudge\dml\abstract_nudge_db
+ * @testdox Whilst subclassing and using a abstract nudge database modification layer
+ */
+class abstract_nudge_db_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        parent::setUp();
+
+        $this->resetAfterTest();
+
+        // Ignore time for these tests.
+        $CFG->nudgemocktime = 1;
+    }
+
+    /**
+     * @test
+     * @testdox calling create or refresh correctly changes the database state and returns an instance of nudge.
+     * @covers ::create_or_refresh
+     */
+    public function test_create_or_refresh(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        $nudge = nudge_db::create_or_refresh(new nudge());
+        $this->assertInstanceOf(nudge::class, $nudge);
+        $this->assertEquals(1, $DB->count_records(nudge_db::$table));
+
+        $nudge->title = 'xyz';
+        $resultingnudge = nudge_db::create_or_refresh($nudge);
+        $this->assertInstanceOf(nudge::class, $resultingnudge);
+        $this->assertEquals('xyz', $DB->get_field(nudge_db::$table, 'title', ['id' => $nudge->id]));
+
+        $this->assertEquals($nudge, $resultingnudge);
+    }
+
+    /**
+     * @test
+     * @testdox calling get by id will return the correct record.
+     * @covers ::get_by_id
+     */
+    public function test_get_by_id(): void
+    {
+        $nudge = nudge_db::create_or_refresh(new nudge());
+
+        $resultingnudge = nudge_db::get_by_id($nudge->id);
+
+        $this->assertEquals($nudge, $resultingnudge);
+    }
+
+    /**
+     * @test
+     * @testdox providing a negative integer to get by id will throw an exception
+     * @covers ::get_by_id
+     */
+    public function test_get_by_id_invalid(): void
+    {
+        $this->expectException(coding_exception::class);
+        nudge_db::get_by_id(-1);
+    }
+
+    public function provide_get_all_classes(): array
+    {
+        return [
+            'nudge' => [
+                nudge::class, nudge_db::class
+            ],
+            'nudge notification' => [
+                nudge_notification::class, nudge_notification_db::class
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox using get all will correctly return all $_dataName instances saved to the database.
+     * @covers ::get_all
+     * @dataProvider provide_get_all_classes
+     */
+    public function test_get_all(string $class, string $dml): void
+    {
+        $inital = nudge_db::get_all();
+        $this->assertIsArray($inital);
+        $this->assertCount(0, $inital);
+
+        /** @var class-string|string $class */
+        /** @var class-string|string $dml */
+
+        /** @var array<abstract_nudge_entity> $instancearray */
+        $instancearray = [];
+        for ($i = 0; $i != 5; $i++) {
+            $instancearray[] = $dml::create_or_refresh(new $class([
+                'title' => 'instance' . (string) $i
+            ]));
+        }
+
+        $resultarray = $dml::get_all();
+        $this->assertIsArray($resultarray);
+
+        for ($i = 0; $i != 5; $i++) {
+            $this->assertArrayHasKey($i, $instancearray);
+            $this->assertArrayHasKey($i, $resultarray);
+
+            $this->assertInstanceOf($class, $resultarray[$i]);
+            $this->assertEquals($instancearray[$i], $resultarray[$i]);
+        }
+    }
+
+    /**
+     * @test
+     * @testdox calling get filtered will return the desired record.
+     * @covers ::get_filtered
+     */
+    public function test_get_filtered(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        $this->assertNull(nudge_db::get_filtered(['id' => 9999999]));
+
+        $nudge = new nudge();
+        $nudge->isenabled = true;
+        $nudge = nudge_db::create_or_refresh($nudge);
+
+        $nottherightnudge = new nudge();
+        nudge_db::save($nottherightnudge);
+
+        $this->assertEquals(2, $DB->count_records(nudge_db::$table));
+
+        $resultingnudge = nudge_db::get_filtered([
+            'isenabled' => true
+        ]);
+
+        $this->assertInstanceOf(nudge::class, $resultingnudge);
+        $this->assertEquals($nudge, $resultingnudge);
+    }
+
+    /**
+     * @test
+     * @testdox calling get all filtered finds the correct records.
+     * @covers ::get_all_filtered
+     */
+    public function test_get_all_filtered(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        $inital = nudge_db::get_all_filtered(['id' => 9999999]);
+        $this->assertIsArray($inital);
+        $this->assertCount(0, $inital);
+
+        /** @var array<nudge> $disabledinstances */
+        $disabledinstances = [];
+
+        for ($i = 0; $i != 5; $i++) {
+            // Some enabled instances.
+            nudge_db::create_or_refresh(new nudge([
+                'isenabled' => true
+            ]));
+
+            $rng = (string) \rand() & 5;
+            $disabledinstances[] = nudge_db::create_or_refresh(new nudge([
+                'title' => "disabled instance {$rng}"
+            ]));
+        }
+
+        $this->assertEquals(10, $DB->count_records(nudge_db::$table));
+        $this->assertEquals(5, $DB->count_records(nudge_db::$table, ['isenabled' => true]));
+        $this->assertEquals(5, $DB->count_records(nudge_db::$table, ['isenabled' => false]));
+
+        $resultarray = nudge_db::get_all_filtered([
+            'isenabled' => false
+        ]);
+        $this->assertCount(5, $resultarray);
+
+        for ($i = 0; $i != 5; $i++) {
+            $this->assertArrayHasKey($i, $resultarray);
+            $this->assertInstanceOf(nudge::class, $resultarray[$i]);
+
+            $this->assertEquals($disabledinstances, $resultarray);
+        }
+    }
+
+    /**
+     * @test
+     * @testdox calling get sql with a simple queries will correctly wrap the record with an entity instance.
+     * @covers ::get_sql
+     */
+    public function test_get_sql(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+        $table = nudge_db::$table;
+        $basesql = <<<SQL
+            SELECT
+                n.*
+            FROM
+                {{$table}} as n
+            WHERE
+                [[WHERE]]
+        SQL;
+
+        $nudge = nudge_db::create_or_refresh(new nudge(['title' => 'filterable']));
+        $this->assertEquals(1, $DB->count_records($table));
+
+        $resultingnudge = nudge_db::get_sql(\strtr(
+            $basesql,
+            ['[[WHERE]]' => "n.id = {$nudge->id}"]
+        ));
+        $this->assertInstanceOf(nudge::class, $resultingnudge);
+        $this->assertEquals($nudge, $resultingnudge);
+
+        $paramnudge = nudge_db::get_sql(\strtr(
+            $basesql,
+            ['[[WHERE]]' => 'n.id = :id']
+        ), ['id' => $nudge->id]);
+        $this->assertInstanceOf(nudge::class, $paramnudge);
+        $this->assertEquals($nudge, $paramnudge);
+
+        $nullresult = nudge_db::get_sql(\strtr(
+            $basesql,
+            ['[[WHERE]]' => 'n.id = 999999999']
+        ));
+        $this->assertNull($nullresult);
+    }
+
+    /**
+     * @test
+     * @testdox calling get all sql with a filtering query will return the correctly filtered and wrapped instances.
+     * @covers ::get_all_sql
+     */
+    public function test_get_all_sql(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+        $table = nudge_db::$table;
+
+        $inital = nudge_db::get_all_filtered(['id' => 9999999]);
+        $this->assertIsArray($inital);
+        $this->assertCount(0, $inital);
+
+        /** @var array<nudge> $disabledinstances */
+        $disabledinstances = [];
+
+        for ($i = 0; $i != 5; $i++) {
+            // Some enabled instances.
+            nudge_db::create_or_refresh(new nudge([
+                'isenabled' => true
+            ]));
+
+            $rng = (string) \rand() & 5;
+            $disabledinstances[] = nudge_db::create_or_refresh(new nudge([
+                'title' => "disabled instance {$rng}"
+            ]));
+        }
+
+        $this->assertEquals(10, $DB->count_records($table));
+        $this->assertEquals(5, $DB->count_records($table, ['isenabled' => true]));
+        $this->assertEquals(5, $DB->count_records($table, ['isenabled' => false]));
+
+        $resultarray = nudge_db::get_all_sql(<<<SQL
+            SELECT
+                n.*
+            FROM
+                {{$table}} as n
+            WHERE
+                n.isenabled = 0
+        SQL);
+        $this->assertCount(5, $resultarray);
+
+        for ($i = 0; $i != 5; $i++) {
+            $this->assertArrayHasKey($i, $resultarray);
+            $this->assertInstanceOf(nudge::class, $resultarray[$i]);
+
+            $this->assertEquals($disabledinstances, $resultarray);
+        }
+    }
+
+    /**
+     * @test
+     * @testdox calling save to persist a record works as expected.
+     * @covers ::save
+     */
+    public function test_save_persists(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        $this->setUser($this->getDataGenerator()->create_user());
+
+        $nudge = new nudge();
+        $nudge->title = 'custom';
+
+        $nudgeid = nudge_db::save($nudge);
+
+        // The record being saved should be cloned so these should not be changed.
+        $this->assertEquals(0, $nudge->lastmodified);
+        $this->assertEquals(0, $nudge->lastmodifiedby);
+        $this->assertEquals(0, $nudge->createdby);
+        $this->assertEquals(0, $nudge->timecreated);
+
+        $resultingnudge = $DB->get_record(nudge_db::$table, ['id' => $nudgeid]);
+        $this->assertIsObject($resultingnudge);
+
+        $this->assertEquals($nudge->title, $resultingnudge->title);
+        // Control fields should be present on the new record.
+        $this->assertGreaterThan(0, $resultingnudge->lastmodified);
+        $this->assertGreaterThan(0, $resultingnudge->lastmodifiedby);
+        $this->assertGreaterThan(0, $resultingnudge->createdby);
+        $this->assertGreaterThan(0, $resultingnudge->timecreated);
+    }
+
+    /**
+     * @test
+     * @testdox calling save to update a record correctly changes the database values
+     * @covers ::save
+     */
+    public function test_save_updates(): void
+    {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        $this->setUser($this->getDataGenerator()->create_user());
+
+        $nudge = new nudge();
+        $nudge->title = 'custom';
+
+        $nudgeid = nudge_db::save($nudge);
+
+        $resultingnudge = $DB->get_record(nudge_db::$table, ['id' => $nudgeid]);
+        $this->assertIsObject($resultingnudge);
+        $this->assertIsString($resultingnudge->title);
+        $this->assertEquals('custom', $resultingnudge->title);
+
+        // Should be able to instance from this stdClass.
+        $resultingnudge->title = 'new title';
+        nudge_db::save(new nudge($resultingnudge));
+
+        $this->assertEquals(1, $DB->count_records(nudge_db::$table), 'Saving should update the existing record');
+        $updatednudge = $DB->get_record(nudge_db::$table, ['id' => $nudgeid]);
+
+        $this->assertIsObject($updatednudge);
+        $this->assertEquals('new title', $updatednudge->title);
+    }
+
+    /**
+     * @test
+     * @testdox calling save will result in the correct hooks being called
+     * @covers ::save
+     */
+    public function test_save_calls_hooks(): void
+    {
+        $this->markTestIncomplete('TODO');
+    }
+
+    // The delete functions are not covered as they are rather shallow wrappers just provided for consistency.
+
+    public function provide_populate_defaults_classes(): array
+    {
+        return [
+            'nudge' => [
+                nudge::class, nudge_db::class
+            ],
+            'nudge notification' => [
+                nudge_notification::class, nudge_notification_db::class
+            ],
+            'nudge notification content' => [
+                nudge_notification_content::class, nudge_notification_content_db::class
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @testdox manually populating defaults for a $_dataName instance using the public API works.
+     * @covers ::populate_defaults
+     * @dataProvider provide_populate_defaults_classes
+     */
+    public function test_populate_defaults(string $class, string $dml): void
+    {
+        /** @var class-string|string $class */
+        /** @var class-string|string $dml */
+
+        $instance = new $class();
+        $instancevars = array_keys(get_class_vars($class));
+
+        foreach ($instancevars as $prop) {
+            // 'Loosely' not set, using booleans since null casting was removed.
+            $this->assertFalse((bool) $instance->{$prop});
+        }
+
+        $dml::populate_defaults($instance);
+
+        foreach ($instancevars as $prop) {
+            $defaultval = $class::DEFAULTS[$prop] ?? false;
+            if ($defaultval) {
+                $this->assertEquals($defaultval, $instance->{$prop});
+            }
+        }
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/dml/nudge_notification_db_test.php
+++ b/tests/testclasses/dml/nudge_notification_db_test.php
@@ -1,0 +1,129 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Squiz.PHP.CommentedOutCode
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @package     local_nudge\tests\dml
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\dml;
+
+use advanced_testcase;
+use local_nudge\dml\nudge_db;
+use local_nudge\dml\nudge_notification_db;
+use local_nudge\local\nudge;
+use local_nudge\local\nudge_notification;
+
+/**
+ * @coversDefaultClass \local_nudge\dml\nudge_notification_db
+ * @testdox Whilst subclassing and using a abstract nudge database modification layer
+ */
+class nudge_notification_db_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetAfterTest();
+    }
+
+    /**
+     * @test
+     * @testdox deleting a nudge notification will unlink it from any attached nudges.
+     * @covers ::delete
+     */
+    public function test_delete_unsets_attached_nudges(): void
+    {
+        $this->redirectMessages();
+
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+
+        $course = $this->getDataGenerator()->create_course();
+        $nudge = new nudge();
+        $nudge->courseid = $course->id;
+        $nudge->linkedlearnernotificationid = $notification->id;
+        $nudge->linkedmanagernotificationid = $notification->id;
+        $nudge->isenabled = true;
+        $nudgeid = nudge_db::save($nudge);
+
+        $this->assertCount(
+            1,
+            nudge_db::get_all_filtered([
+                'linkedlearnernotificationid' => $notification->id,
+                'linkedmanagernotificationid' => $notification->id,
+                'isenabled' => true
+            ])
+        );
+
+        nudge_notification_db::delete($notification->id);
+
+        $modifiednudge = nudge_db::get_by_id($nudgeid);
+        $this->assertFalse($modifiednudge->isenabled);
+        $this->assertEquals(0, $modifiednudge->linkedlearnernotificationid);
+        $this->assertEquals(0, $modifiednudge->linkedmanagernotificationid);
+    }
+
+
+    /**
+     * @test
+     * @testdox when deleting a nudge notification if there are removed nudge links emails are sent to the nudge's owner.
+     * @covers ::send_deletion_message
+     * @covers \local_nudge\local\nudge::notify_owners
+     */
+    public function test_delete_emails_owners(): void
+    {
+        $sink = $this->redirectMessages();
+
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+
+        $creatinguser = $this->getDataGenerator()->create_user();
+        $updatinguser = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course();
+        $nudge = new nudge();
+        $nudge->courseid = $course->id;
+        $nudge->linkedlearnernotificationid = $notification->id;
+        $nudge->linkedmanagernotificationid = $notification->id;
+        $nudge->isenabled = true;
+
+        $this->setUser($creatinguser);
+        $nudge = nudge_db::create_or_refresh($nudge);
+
+        $this->setUser($updatinguser);
+        $nudge = nudge_db::create_or_refresh($nudge);
+
+        nudge_notification_db::delete($notification->id);
+
+        $this->assertEquals(4, $sink->count());
+
+        $messagesgot = $sink->get_messages();
+        $receipts = \array_column($messagesgot, 'useridto');
+        $this->assertContains($creatinguser->id, $receipts);
+        $this->assertContains($updatinguser->id, $receipts);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/dto/nudge_notification_form_data_test.php
+++ b/tests/testclasses/dto/nudge_notification_form_data_test.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @package     local_nudge\tests\dto
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\dto;
+
+use advanced_testcase;
+use coding_exception;
+use local_nudge\dto\nudge_notification_form_data;
+use local_nudge\local\nudge_notification;
+use local_nudge\local\nudge_notification_content;
+use stdClass;
+
+/**
+ * @coversDefaultClass \local_nudge\dto\nudge_notification_form_data
+ * @testdox When packing a nudge notification form data transfer object
+ */
+class nudge_notification_form_data_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @testdox providing invalid data results in a coding exception.
+     * @covers ::__construct
+     */
+    public function test_dto_invalid_exception(): void
+    {
+        $this->expectException(coding_exception::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Coding error detected, it must be fixed by a programmer: You must pass an instance of %s as notificationcontent',
+            nudge_notification_content::class
+        ));
+
+        // Since this is mostly packaged by {@see nudge_notification::as_notification_form()}
+        // throwing a coding exception should only really happen during development.
+        new nudge_notification_form_data(
+            new nudge_notification(),
+            [
+                new nudge_notification_content(),
+                new stdClass
+            ]
+        );
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/event/nudge_event_test.php
+++ b/tests/testclasses/event/nudge_event_test.php
@@ -27,7 +27,9 @@ namespace local_nudge\testclasses\event;
 use advanced_testcase;
 use context_course;
 use local_nudge\dml\nudge_db;
+use local_nudge\event\nudge_created;
 use local_nudge\local\nudge;
+use moodle_url;
 
 use const CONTEXT_COURSE;
 
@@ -57,7 +59,9 @@ class nudge_event_test extends advanced_testcase {
      * @test
      * @large
      * @testdox Saving should create a new nudge_created event.
-     * @covers local_nudge\event\nudge_created
+     *
+     * @covers \local_nudge\event\nudge_created
+     * @covers \local_nudge\dml\nudge_db::on_after_create
      */
     public function test_nudge_created_event(): void
     {
@@ -98,7 +102,8 @@ class nudge_event_test extends advanced_testcase {
      * @test
      * @large
      * @testdox Deleting should create a new nudge_deleted event.
-     * @covers local_nudge\event\nudge_deleted
+     * @covers \local_nudge\event\nudge_deleted
+     * @covers \local_nudge\dml\nudge_db::on_before_delete
      */
     public function test_nudge_deleted_event(): void
     {
@@ -158,7 +163,8 @@ class nudge_event_test extends advanced_testcase {
      * @test
      * @large
      * @testdox Saving an existing instance should create a new nudge_updated event.
-     * @covers local_nudge\event\nudge_updated
+     * @covers \local_nudge\event\nudge_updated
+     * @covers \local_nudge\dml\nudge_db::on_after_save
      */
     public function test_nudge_updated_event(): void
     {

--- a/tests/testclasses/form/nudge/delete_test.php
+++ b/tests/testclasses/form/nudge/delete_test.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_nudge\testclasses\form\nudge
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\form\nudge;
+
+use advanced_testcase;
+use local_nudge\form\nudge\delete;
+use stdClass;
+
+// phpcs:disable moodle.Files.LineLength
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @coversDefaultClass \local_nudge\form\nudge\delete
+ * @testdox When working with a nudge delete form
+ */
+class delete_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetAfterTest();
+    }
+
+    /**
+     * @test
+     * @testdox using a delete {@see nudge} form returns a stdClass to delete.
+     * @covers ::definition
+     */
+    public function test_nudge_delete_submit(): void
+    {
+        $_POST = [
+            'id' => '0',
+            'courseid' => '0',
+            'sesskey' => \sesskey(),
+            '_qf__local_nudge_form_nudge_delete' => '1',
+            'submitbutton' => 'Delete',
+        ];
+
+        $this->assertIsObject($this->get_form_data());
+    }
+
+    /**
+     * Gets the submited result of a {@see nudge} {@see delete} form.
+     *
+     * @return stdClass|null
+     */
+    private function get_form_data(): ?stdClass
+    {
+        $edit = new delete();
+        $this->assertFalse($edit->is_cancelled());
+        return $edit->get_data();
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/form/nudge/edit_test.php
+++ b/tests/testclasses/form/nudge/edit_test.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * @package     local_nudge\tests
+ * @package     local_nudge\testclasses\form\nudge
  * @author      Liam Kearney <liam@sproutlabs.com.au>
  * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
  * @license     http://www.gnu.org/copyleft/gpl.html
@@ -25,40 +25,222 @@
 namespace local_nudge\testclasses\form\nudge;
 
 use advanced_testcase;
+use local_nudge\dml\nudge_notification_db;
+use local_nudge\form\nudge\edit;
+use local_nudge\local\nudge;
+use local_nudge\local\nudge_notification;
 
-// phpcs:disable moodle.Commenting
+// phpcs:disable moodle.Files.LineLength
 // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
 // phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
 
 /**
+ * @coversDefaultClass \local_nudge\form\nudge\edit
  * @testdox When working with a nudge form
+ *
+ * An aside when working with HTMLQuickform via $_POST mocking, Sometimes it will be a giant PIA to debug.
+ * One of the key things to remember is that it takes a dynamic moodleform definition into account.
+ *
+ * So if you $_POST a value for a select that gets populated from the database it may silently omit
+ * that value if there isn't any data avalible.
  */
 class edit_test extends advanced_testcase {
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->resetAfterTest();
+        $this->mock_nudge_edit_form_post();
     }
 
     /**
+     * Covers since there is only one rule in definition at the time of testing.
+     *
      * @test
-     * @testdox User without capability can't submit.
+     * @testdox attempting to save a {@see nudge} without a title will not work.
+     * @covers ::definition
+     * @covers ::get_data
      */
-    public function test_user_without_cap_cant_submit(): void
+    public function test_nudge_edit_submit_required_title(): void
     {
-        $this->assertTrue(true);
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+        $_POST['linkedlearnernotificationid'] = $notification->id;
+        $this->assertNotNull($this->get_form_data(), 'Setting up the learner notification should be valid.');
+
+        unset($_POST['group_header']['title']);
+        $this->assertNull($this->get_form_data());
     }
 
     /**
      * @test
-     * @testdox User with capability can submit.
+     * @testdox Submitting a form with {@see nudge::REMINDER_RECIPIENT_BOTH} requires two selected {@see nudge_notification}s.
+     * @covers ::validation
+     * @covers ::get_data
+     */
+    public function test_nudge_edit_submit_recipient_both(): void
+    {
+        $_POST['reminderrecipient'] = nudge::REMINDER_RECIPIENT_BOTH;
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+
+        $this->assertStringContainsString(
+            'The selected recipient type was: "Both the Learner and their Managers" but there wasn\'t wasn\'t enough notifications to cover the recipients.',
+            $this->get_form_display()
+        );
+
+        $_POST['linkedlearnernotificationid'] = $notification->id;
+        $this->assertNull($this->get_form_data(), 'Still needs another notification');
+
+        $_POST['linkedmanagernotificationid'] = $notification->id;
+        $data = $this->get_form_data();
+        $this->assertNotNull($data);
+        $this->assertInstanceOf(nudge::class, $data);
+        $this->assertEquals($notification->id, $data->linkedlearnernotificationid);
+        $this->assertEquals($notification->id, $data->linkedmanagernotificationid);
+    }
+
+    /**
+     * @test
+     * @testdox Submitting a form with {@see nudge::REMINDER_RECIPIENT_LEARNER} requires one selected {@see nudge_notification}.
+     * @covers ::validation
+     * @covers ::get_data
+     */
+    public function test_nudge_edit_submit_recipient_learner(): void
+    {
+        $_POST['reminderrecipient'] = nudge::REMINDER_RECIPIENT_LEARNER;
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+
+        $this->assertStringContainsString(
+            'The selected recipient type was: "The Learner" but there wasn\'t wasn\'t enough notifications to cover the recipients.',
+            $this->get_form_display()
+        );
+
+        $_POST['linkedlearnernotificationid'] = $notification->id;
+
+        $data = $this->get_form_data();
+        $this->assertNotNull($data);
+        $this->assertInstanceOf(nudge::class, $data);
+        $this->assertEquals($notification->id, $data->linkedlearnernotificationid);
+        $this->assertEquals(0, $data->linkedmanagernotificationid);
+    }
+
+    /**
+     * @test
+     * @testdox Submitting a form with {@see nudge::REMINDER_RECIPIENT_MANAGERS} requires one selected {@see nudge_notification}.
+     * @covers ::validation
+     * @covers ::get_data
+     */
+    public function test_nudge_edit_submit_recipient_manager(): void
+    {
+        $_POST['reminderrecipient'] = nudge::REMINDER_RECIPIENT_MANAGERS;
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+
+        $this->assertStringContainsString(
+            'The selected recipient type was: "The Learner\'s Managers" but there wasn\'t wasn\'t enough notifications to cover the recipients.',
+            $this->get_form_display()
+        );
+
+        $_POST['linkedmanagernotificationid'] = $notification->id;
+
+        $data = $this->get_form_data();
+        $this->assertNotNull($data);
+        $this->assertInstanceOf(nudge::class, $data);
+        $this->assertEquals($notification->id, $data->linkedmanagernotificationid);
+        $this->assertEquals(0, $data->linkedlearnernotificationid);
+    }
+
+    /**
+     * @test
+     * @testdox Submitting a form with {@see nudge::REMINDER_DATE_INPUT_FIXED} validates the date against the courses end date.
+     * @covers ::validation
+     * @covers ::get_data
+     */
+    public function test_nudge_edit_submit_fixed_validate_courseend(): void
+    {
+        $notification = nudge_notification_db::create_or_refresh(new nudge_notification());
+        $_POST['linkedlearnernotificationid'] = $notification->id;
+
+        $initaltimestamp = \time();
+
+        $course = $this->getDataGenerator()->create_course(['enddate' => $initaltimestamp]);
+        $_POST['courseid'] = $course->id;
+
+        $_POST['remindertypefixeddate']['day']   = \date('j', $initaltimestamp);
+        $_POST['remindertypefixeddate']['month']   = \date('n', $initaltimestamp);
+        $_POST['remindertypefixeddate']['year']   = \date('Y', $initaltimestamp + \YEARSECS);
+
+        $this->assertStringContainsString(
+            \get_string(
+                'validation_nudge_timepastcourseend',
+                'local_nudge',
+                \date(nudge::DATE_FORMAT_NICE, $initaltimestamp)
+            ),
+            $this->get_form_display()
+        );
+    }
+
+    /**
+     * Gets the submited result of a {@see nudge} {@see edit} form.
+     *
+     * @return nudge|null
+     */
+    private function get_form_data(): ?nudge
+    {
+        $edit = new edit();
+        $this->assertFalse($edit->is_cancelled());
+        return $edit->get_data();
+    }
+
+    /**
+     * Gets a {@see nudge} {@see edit} form's HTML output.
+     *
+     * This is for validation its not ideal to scan the string but I can't find the right API right now.
+     *
+     * @return string
+     */
+    private function get_form_display(): string
+    {
+        $edit = new edit();
+        $this->assertFalse($edit->is_cancelled());
+        $edit->get_data();
+
+        \ob_start();
+        $edit->display();
+        return \ob_get_clean() ?: '';
+    }
+
+    /**
+     * Mocks a simple post to {@see nudge}'s {@see edit} form.
      *
      * @return void
      */
-    public function test_user_with_cap_can_submit(): void
+    private function mock_nudge_edit_form_post(): void
     {
-        $this->assertTrue(true);
+        $course = $this->getDataGenerator()->create_course([
+            'enddate' => (\time() + (\YEARSECS * 10))
+        ]);
+        $_POST = [
+            'id' => '0',
+            'courseid' => (string) $course->id,
+            'sesskey' => \sesskey(),
+            '_qf__local_nudge_form_nudge_edit' => '1',
+            'group_header' => [
+                'title' => 'testing',
+                'isenabled' => '1'
+            ],
+            'reminderrecipient' => nudge::REMINDER_RECIPIENT_LEARNER,
+            'remindertype' => nudge::REMINDER_DATE_INPUT_FIXED,
+            'remindertypefixeddate' => [
+                'day' => '6',
+                'month' => '4',
+                'year' => '2022',
+            ],
+            'submitbutton' => 'Save changes',
+        ];
     }
 
+    /**
+     * @return void
+     */
     public function tearDown(): void
     {
         parent::tearDown();

--- a/tests/testclasses/form/nudge_notification/delete_test.php
+++ b/tests/testclasses/form/nudge_notification/delete_test.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_nudge\testclasses\form\nudge_notification
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\form\nudge_notification;
+
+use advanced_testcase;
+use local_nudge\form\nudge_notification\delete;
+use stdClass;
+
+// phpcs:disable moodle.Files.LineLength
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @coversDefaultClass \local_nudge\form\nudge_notification\delete
+ * @testdox When working with a nudge notification delete form
+ */
+class delete_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetAfterTest();
+    }
+
+    /**
+     * @test
+     * @testdox using a delete {@see nudge_notification} form returns a stdClass to delete.
+     * @covers ::definition
+     */
+    public function test_nudge_delete_submit(): void
+    {
+        $_POST = [
+            'id' => '0',
+            'courseid' => '0',
+            'sesskey' => \sesskey(),
+            '_qf__local_nudge_form_nudge_notification_delete' => '1',
+            'submitbutton' => 'Delete',
+        ];
+
+        $this->assertIsObject($this->get_form_data());
+    }
+
+    /**
+     * Gets the submited result of a {@see nudge_notification} {@see delete} form.
+     *
+     * @return stdClass|null
+     */
+    private function get_form_data(): ?stdClass
+    {
+        $edit = new delete();
+        $this->assertFalse($edit->is_cancelled());
+        return $edit->get_data();
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/form/nudge_notification/edit_test.php
+++ b/tests/testclasses/form/nudge_notification/edit_test.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * @package     local_nudge\tests
+ * @package     local_nudge\testclasses\form\nudge_notification
  * @author      Liam Kearney <liam@sproutlabs.com.au>
  * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
  * @license     http://www.gnu.org/copyleft/gpl.html
@@ -25,28 +25,210 @@
 namespace local_nudge\testclasses\form\nudge_notification;
 
 use advanced_testcase;
+use local_nudge\dto\nudge_notification_form_data;
+use local_nudge\form\nudge_notification\edit;
+use local_nudge\local\nudge_notification;
+use local_nudge\local\nudge_notification_content;
 
 // phpcs:disable moodle.Commenting
 // phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
 // phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
 
 /**
+ * @coversDefaultClass \local_nudge\form\nudge_notification\edit
  * @testdox When working with a nudge notifification form
  */
 class edit_test extends advanced_testcase {
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->resetAfterTest();
+        $this->mock_nudge_notification_edit_form_post();
+
+        // Hacky, the html editor element checks for a page url.
+        global $PAGE;
+        /** @var \moodle_page $PAGE */
+        $PAGE->set_url('/xyz/testing');
     }
 
-    public function test_user_without_cap_cant_submit(): void
+    /**
+     * @test
+     * @testdox a simple submission passes validation and returns the correct result.
+     * @covers ::definition
+     * @covers ::get_data
+     */
+    public function test_nudge_notification_edit_submit(): void
     {
-        $this->assertTrue(true);
+        $submission = $this->get_form_data();
+        $this->assertNotNull($submission);
+        $this->assertInstanceOf(nudge_notification_form_data::class, $submission);
+
+        $this->assertInstanceOf(nudge_notification::class, $submission->notification);
+
+        $this->assertCount(2, $submission->notificationcontents);
+        foreach ($submission->notificationcontents as $contents) {
+            $this->assertInstanceOf(nudge_notification_content::class, $contents);
+        }
     }
 
-    public function test_user_with_cap_can_submit(): void
+    /**
+     * @test
+     * @testdox clientside validation works as expected
+     * @covers ::definition
+     * @covers ::get_data
+     */
+    public function test_nudge_notification_edit_submit_client_validation(): void
     {
-        $this->assertTrue(true);
+        // Initally it works.
+        $this->assertInstanceOf(nudge_notification_form_data::class, $this->get_form_data());
+
+        unset($_POST['title']);
+        $this->assertStringContainsString(
+            get_string('validation_notification_needtitle', 'local_nudge'),
+            $this->get_form_display(),
+            'A nudge notification should validate for a title'
+        );
+        $this->assertNull($this->get_form_data());
+        $this->mock_nudge_notification_edit_form_post();
+        // Also check that the reset works.
+        $this->assertInstanceOf(nudge_notification_form_data::class, $this->get_form_data());
+
+        unset($_POST['userfromid']);
+        $this->assertStringContainsString(
+            get_string('validation_notification_needsender', 'local_nudge'),
+            $this->get_form_display(),
+            'A nudge notifciation form should validate for a sender'
+        );
+        $this->assertNull($this->get_form_data());
+        $this->mock_nudge_notification_edit_form_post();
+
+        unset($_POST['lang'][0]);
+        $this->assertStringContainsString(
+            'You must supply a value here.',
+            $this->get_form_display(),
+            'A nudge notification form should validate each content has a language set'
+        );
+        $this->assertNull($this->get_form_data());
+        $this->mock_nudge_notification_edit_form_post();
+
+        unset($_POST['lang'][1]);
+        $this->assertStringContainsString(
+            'You must supply a value here.',
+            $this->get_form_display(),
+            'A nudge notification form should validate each content has a subject set'
+        );
+        $this->assertNull($this->get_form_data());
+        $this->mock_nudge_notification_edit_form_post();
+
+        unset($_POST['body'][0]);
+        $this->assertStringContainsString(
+            'You must supply a value here.',
+            $this->get_form_display(),
+            'A nudge notification form should validate each content has a subject set'
+        );
+        $this->assertNull($this->get_form_data());
+        $this->mock_nudge_notification_edit_form_post();
+    }
+
+    /**
+     * @test
+     * @testdox it validates that you can only have one translation for each language
+     * @covers ::validation
+     * @covers ::get_data
+     */
+    public function test_nudge_notification_edit_submit_validate_onelang(): void
+    {
+        $_POST['hiddenrepeat'] = (string) (((int) $_POST['hiddenrepeat']) + 1);
+        $_POST['contentid'][] = '7';
+        $_POST['lang'][] = 'en';
+        $_POST['subject'][] = 'xyz';
+        $_POST['body'][] = [
+            'text' => 'duplicate',
+            'format' => \FORMAT_HTML,
+        ];
+        $this->assertNull($this->get_form_data());
+        $this->assertStringContainsString(
+            get_string('validation_notification_duplicatelangs', 'local_nudge'),
+            $this->get_form_display(),
+            'A nudge notification form should flag the duplicate english translations'
+        );
+    }
+
+    /**
+     * Gets the submited result of a {@see nudge_notification} {@see edit} form.
+     *
+     * @return nudge_notification_form_data|null
+     */
+    private function get_form_data(): ?nudge_notification_form_data
+    {
+        $edit = new edit();
+        $this->assertFalse($edit->is_cancelled());
+        return $edit->get_data();
+    }
+
+    /**
+     * Gets a {@see nudge} {@see edit} form's HTML output.
+     *
+     * This is for validation its not ideal to scan the string but I can't find the right API right now.
+     *
+     * @return string
+     */
+    private function get_form_display(): string
+    {
+        $edit = new edit();
+        $this->assertFalse($edit->is_cancelled());
+        $edit->get_data();
+
+        \ob_start();
+        $edit->display();
+        return \ob_get_clean() ?: '';
+    }
+
+    /**
+     * Mocks a simple post to {@see nudge}'s {@see edit} form.
+     *
+     * @return void
+     */
+    private function mock_nudge_notification_edit_form_post(): void
+    {
+        // phpcs:disable moodle.Files.LineLength
+        $_POST = [
+            'id' => '0',
+            'hiddenrepeat' => '2',
+            'contentid' => [
+                '3',
+                '5'
+            ],
+            'sesskey' => \sesskey(),
+            '_qf__local_nudge_form_nudge_notification_edit' => '1',
+            'title' => 'Example Notification',
+            'userfromid' => '2',
+            'lang' => [
+                'fr',
+                'en',
+            ],
+            'subject' => [
+                'Example Subject',
+                'French Version - Reminder for {course_fullname}'
+            ],
+            'body' => [
+                [
+                    'text' => <<<HTML
+                    <p dir="ltr"><span style="font-style: normal;">Hi, {user_firstname},</span></p><p dir="ltr"><span style="font-style: normal;"><br></span></p><p dir="ltr"><span style="font-style: normal;">We'd really like to see you complete course: {course_fullname}.</span></p><p dir="ltr"><span style="font-style: normal;">Can you please login via {course_link} and check your completion is up to date.</span></p><p dir="ltr"><span style="font-style: normal;"><br></span></p><p dir="ltr"><span style="font-style: normal;">Thanks, {sender_firstname}.</span></p>
+                    HTML,
+                    'format' => \FORMAT_HTML
+                ],
+                [
+                    'text' => <<<HTML
+                    <p dir="ltr" style="text-align: left;"><em><em></em></em></p><fieldset id="id_translationhdr_0"><div><div id="fitem_id_body_0"><div data-fieldtype="editor"><div><div><div><div><div id="id_body_0editable" contenteditable="true" role="textbox" spellcheck="true" aria-live="off" aria-labelledby="yui_3_17_2_1_1649751013735_115"><p dir="ltr"><span><span style="font-style: normal;"><strong>Hi</strong>, {user_firstname},</span></span></p><p dir="ltr"><span><span style="font-style: normal;"><br></span></span></p><p dir="ltr"><span><span style="font-style: normal;">We'd really like to see you complete the course: <strong>{course_fullname}</strong>.</span></span></p><p dir="ltr"><span><span style="font-style: normal;">Can you please login via {course_link} and check your completion is up to date.</span></span></p><p dir="ltr"><span><span style="font-style: normal;"><br></span></span></p><p dir="ltr"><span><span style="font-style: normal;">Thanks, <strong>{sender_firstname}</strong>.</span></span></p></div></div></div></div></div></div></div></div></fieldset><span></span><br><p></p>
+                    HTML,
+                    'format' => \FORMAT_HTML
+                ]
+            ],
+            'submitbutton' => 'Save changes',
+        ];
+        // phpcs:enable moodle.Files.LineLength
     }
 
     public function tearDown(): void

--- a/tests/testclasses/local/nudge_notification_content_test.php
+++ b/tests/testclasses/local/nudge_notification_content_test.php
@@ -35,27 +35,31 @@ use local_nudge\local\nudge_notification_content;
 // phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
 
 /**
+ * @coversDefaultClass \local_nudge\local\nudge_notification_content
  * @testdox When using a nudge_notification_content entity
  */
 class nudge_notification_content_test extends advanced_testcase {
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->resetAfterTest();
     }
 
     /**
      * @test
      * @testdox Calling get_notification returns the has one in the expected state.
-     * @covers local_nudge\local\nudge_notification_content::get_notification
+     * @covers ::get_notification
      */
     public function test_get_notification(): void
     {
-        $this->resetAfterTest();
-
         /** @var \moodle_database $DB */
         global $DB;
 
-        $notification = new nudge_notification([]);
+        $unlinkedcontent = new nudge_notification_content();
+        $this->assertNull($unlinkedcontent->get_notification());
+
+        $notification = new nudge_notification();
         $notificationid = nudge_notification_db::save($notification);
 
         // Get with defaults and id.
@@ -68,9 +72,31 @@ class nudge_notification_content_test extends advanced_testcase {
         $resultingnotification = $content->get_notification();
 
         $this->assertEquals($notification, $resultingnotification);
+    }
 
-        $DB->delete_records(nudge_notification_db::$table);
-        $DB->delete_records(nudge_notification_content_db::$table);
+
+    /**
+     * @test
+     * @testdox Creating a new instance will return sane correctly typed defaults.
+     * @covers ::cast_fields
+     */
+    public function test_defaults_casted() {
+        /** @var nudge_notification_content */
+        $contents = nudge_notification_content_db::create_or_refresh(
+            new nudge_notification_content()
+        );
+
+        $this->assertIsInt($contents->nudgenotificationid);
+        $this->assertEquals(0, $contents->nudgenotificationid);
+
+        $this->assertIsString($contents->lang);
+        $this->assertEquals(nudge_notification_content::DEFAULTS['lang'], $contents->lang);
+
+        $this->assertIsString($contents->subject);
+        $this->assertEquals(nudge_notification_content::DEFAULTS['subject'], $contents->subject);
+
+        $this->assertIsString($contents->body);
+        $this->assertEquals(nudge_notification_content::DEFAULTS['body'], $contents->body);
     }
 
     public function tearDown(): void

--- a/tests/testclasses/local/nudge_notification_test.php
+++ b/tests/testclasses/local/nudge_notification_test.php
@@ -37,6 +37,7 @@ use local_nudge\local\nudge_notification_content;
 // phpcs:disable moodle.Commenting.InlineComment.TypeHintingMatch
 
 /**
+ * @coversDefaultClass \local_nudge\local\nudge_notification
  * @testdox When using a nudge_notification entity
  */
 class nudge_notification_test extends advanced_testcase {
@@ -49,7 +50,7 @@ class nudge_notification_test extends advanced_testcase {
     /**
      * @test
      * @testdox Calling the get_contents function returns filtered has many instances of nudge_notification_content.
-     * @covers local_nudge\local\nudge_notification::get_contents
+     * @covers ::get_contents
      */
     public function test_get_contents(): void
     {
@@ -58,7 +59,7 @@ class nudge_notification_test extends advanced_testcase {
 
         $this->resetAfterTest();
 
-        $notification = new nudge_notification([]);
+        $notification = new nudge_notification();
         $notificationid = nudge_notification_db::save($notification);
 
         // Refresh the model with it's ID. Save clones the entity and that worth keeping in mind while developing.
@@ -107,8 +108,8 @@ class nudge_notification_test extends advanced_testcase {
     /**
      * @test
      * @testdox Wrapping a {@see nudge_notification} in a {@see nudge_notification_form_data} stores the correct data.
-     * @covers local_nudge\local\nudge_notification::as_notification_form
-     * @covers local_nudge\dto\nudge_notification_form_data
+     * @covers ::as_notification_form
+     * @covers \local_nudge\dto\nudge_notification_form_data
      */
     public function test_as_notification_form(): void
     {
@@ -161,16 +162,16 @@ class nudge_notification_test extends advanced_testcase {
     /**
      * @test
      * @testdox Creating a new instance will return sane correctly typed defaults.
-     * @covers local_nudge\dml\nudge_notification_db::on_before_create
-     * @covers local_nudge\local\nudge_notification::cast_fields
+     * @covers ::cast_fields
+     * @covers \local_nudge\dml\nudge_notification_db::on_before_create
      */
-    public function tests_defaults_casted() {
+    public function test_defaults_casted() {
         /** @var \moodle_database $DB */
         global $DB;
 
         $this->resetAfterTest();
 
-        $notification = new nudge_notification([]);
+        $notification = new nudge_notification();
         $notificationid = nudge_notification_db::save($notification);
         $notification = nudge_notification_db::get_by_id($notificationid);
 

--- a/tests/testclasses/local/nudge_test.php
+++ b/tests/testclasses/local/nudge_test.php
@@ -45,7 +45,7 @@ class nudge_test extends advanced_testcase {
     public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->resetAfterTest();
     }
 

--- a/tests/testclasses/local/nudge_test.php
+++ b/tests/testclasses/local/nudge_test.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 // phpcs:disable moodle.Commenting
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
 
 /**
  * @package     local_nudge\tests
@@ -34,11 +36,8 @@ use local_nudge\local\nudge_notification;
 use moodle_exception;
 use stdClass;
 
-// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
-// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
-// phpcs:disable moodle.Commenting.InlineComment.TypeHintingMatch
-
 /**
+ * @coversDefaultClass \local_nudge\local\nudge
  * @testdox When using a nudge entity
  */
 class nudge_test extends advanced_testcase {
@@ -46,24 +45,21 @@ class nudge_test extends advanced_testcase {
     public function setUp(): void
     {
         parent::setUp();
+        
+        $this->resetAfterTest();
     }
 
     /**
      * @test
      * @testdox Calling get_*_notification returns an instance of nudge_notification.
-     * @covers local_nudge\local\nudge::get_learner_notification
-     * @covers local_nudge\local\nudge::get_manager_notification
+     * @covers ::get_learner_notification
+     * @covers ::get_manager_notification
      */
     public function test_get_notification(): void
     {
-        /** @var \moodle_database $DB */
-        global $DB;
-
-        $this->resetAfterTest();
-
         $courseid = $this->getDataGenerator()->create_course()->id;
 
-        $learnernotification = new nudge_notification([]);
+        $learnernotification = new nudge_notification();
         $nudgenotificationid = nudge_notification_db::save($learnernotification);
 
         $nudge = new nudge([
@@ -78,30 +74,20 @@ class nudge_test extends advanced_testcase {
         $this->assertInstanceOf(nudge_notification::class, $learnerresult);
         $this->assertInstanceOf(nudge_notification::class, $managerresult);
 
-        $nullnudge = new nudge([]);
+        $nullnudge = new nudge();
 
         $expectednull = $nullnudge->get_learner_notification();
         $this->assertNull($expectednull, 'A new nudge without a linked notification should not return anything');
         $expectednull = $nullnudge->get_manager_notification();
-
-        // Cleanup.
-        $DB->delete_records('course');
-        $DB->delete_records(nudge_db::$table);
-        $DB->delete_records(nudge_notification_db::$table);
     }
 
     /**
      * @test
      * @testdox Calling get_course on a nudge instance correctly returns a stdClass representing it's linked course.
-     * @covers local_nudge\local\nudge::get_course
+     * @covers ::get_course
      */
     public function test_get_course(): void
     {
-        /** @var \moodle_database $DB */
-        global $DB;
-
-        $this->resetAfterTest();
-
         $course = $this->getDataGenerator()->create_course();
 
         $nudge = new nudge([
@@ -114,19 +100,17 @@ class nudge_test extends advanced_testcase {
         $this->assertInstanceOf(stdClass::class, $resultcourse);
         $this->assertEquals($course->id, $resultcourse->id);
         $this->assertEquals($course->fullname, $resultcourse->fullname);
-
-        // Cleanup.
-        $DB->delete_records('course');
-        $DB->delete_records(nudge_db::$table);
     }
 
     /**
      * @test
      * @testdox Triggering a nudge with invalid database (or runtime) data fails.
-     * @covers local_nudge\local\nudge::trigger
+     * @covers ::trigger
      */
     public function test_trigger_expected(): void {
-        $nudge = new nudge([]);
+        $this->resetAfterTest(false);
+
+        $nudge = new nudge();
         $nudge->reminderrecipient = 'xyz';
 
         $this->expectException(moodle_exception::class);
@@ -138,24 +122,15 @@ class nudge_test extends advanced_testcase {
     /**
      * @test
      * @testdox Creating a new instance will return sane correctly typed defaults.
-     * @covers local_nudge\local\nudge::cast_fields
+     * @covers ::cast_fields
      */
-    public function tests_defaults_casted() {
-        /** @var \moodle_database $DB */
-        global $DB;
-
-        $this->resetAfterTest();
-
+    public function test_defaults_casted() {
         $nudge = new nudge([
             'courseid' => 1
         ]);
         $nudgeid = nudge_db::save($nudge);
         $nudge = nudge_db::get_by_id($nudgeid);
 
-        /**
-         * Using two instead of assertSame() since its more verbose.
-         * @var nudge $nudge
-        */
         $this->assertIsInt($nudge->courseid);
         $this->assertEquals(1, $nudge->courseid);
 
@@ -179,8 +154,6 @@ class nudge_test extends advanced_testcase {
 
         $this->assertIsInt($nudge->remindertypefixeddate);
         $this->assertEquals(0, $nudge->remindertypefixeddate);
-
-        $DB->delete_records(nudge_db::$table);
     }
 
     public function tearDown(): void

--- a/tests/testclasses/local/nudge_user_test.php
+++ b/tests/testclasses/local/nudge_user_test.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @package     local_nudge\tests
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\local;
+
+use advanced_testcase;
+use local_nudge\dml\nudge_user_db;
+use local_nudge\local\nudge_user;
+
+/**
+ * @coversDefaultClass \local_nudge\local\nudge_user
+ * @testdox When using a nudge user entity
+ */
+class nudge_user_test extends advanced_testcase {
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->resetAfterTest();
+    }
+
+    /**
+     * @test
+     * @testdox Creating a new instance will return sane correctly typed defaults.
+     * @covers ::cast_fields
+     */
+    public function test_defaults_casted() {
+        $nudgeuser = nudge_user_db::create_or_refresh(new nudge_user([
+            'userid' => 1,
+            'nudgeid' => 1,
+        ]));
+
+        $this->assertIsInt($nudgeuser->userid);
+        $this->assertEquals(1, $nudgeuser->userid);
+
+        $this->assertIsInt($nudgeuser->nudgeid);
+        $this->assertEquals(1, $nudgeuser->nudgeid);
+
+        $this->assertIsInt($nudgeuser->recurrancetime);
+        $this->assertEquals(0, $nudgeuser->recurrancetime);
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+    }
+}

--- a/tests/testclasses/task/nudge_task_bench.php
+++ b/tests/testclasses/task/nudge_task_bench.php
@@ -1,0 +1,217 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_nudge\tests
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\task;
+
+use advanced_testcase;
+use local_nudge\dml\nudge_db;
+use local_nudge\dml\nudge_notification_content_db;
+use local_nudge\dml\nudge_notification_db;
+use local_nudge\local\nudge;
+use local_nudge\local\nudge_notification;
+use local_nudge\local\nudge_notification_content;
+use local_nudge\task\nudge_task;
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @testdox When the nudge_tasks runs it should
+ */
+class nudge_task_bench extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @testdox Benchmarking recurring nudge
+     */
+    public function test_send_benchmark_recurring(): void
+    {
+        $usercount = 4_000;
+
+        // -------------------------------
+        //          SETUP TEST
+        // -------------------------------
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->preventResetByRollback();
+
+        $sink = $this->redirectMessages();
+
+        // -------------------------------
+        //          SETUP DATA
+        // -------------------------------
+
+        $time = \time();
+        $CFG->nudgemocktime = $time;
+
+        $course = $this->getDataGenerator()->create_course([]);
+        $sender = $this->getDataGenerator()->create_user();
+        for ($i = $usercount; $i--; $i != 0) {
+            $this->getDataGenerator()->create_and_enrol(
+                $course,
+                'student',
+                null,
+                'manual',
+                $time
+            );
+        }
+
+        // TODO: dataGenerators for nudge, notification and contents.
+        $notification = nudge_notification_db::create_or_refresh(
+            new nudge_notification(['userfromid' => $sender->id])
+        );
+        nudge_notification_content_db::create_or_refresh(new nudge_notification_content([
+            'nudgenotificationid' => $notification->id
+        ]));
+
+        nudge_db::create_or_refresh(new nudge([
+            'isenabled' => 1,
+            'courseid' => $course->id,
+            'linkedlearnernotificationid' => $notification->id,
+            'remindertype' => nudge::REMINDER_DATE_RELATIVE_ENROLLMENT,
+            // Send reminder 2 minutes after enrollment.
+            'remindertypeperiod' => \MINSECS * 2
+        ]));
+
+        // -------------------------------
+        //      PERFORM ASSERTIONS
+        // -------------------------------
+
+        (new nudge_task)->execute();
+
+        $this->assertEquals(0, $sink->count(), 'There should be an no message to any user yet.');
+
+        $CFG->nudgemocktime += (\MINSECS * 2);
+
+        $start = \time();
+        (new nudge_task)->execute();
+        $total = \time() - $start;
+        printf(
+            \str_repeat(\PHP_EOL, 2) .
+            '------' . \PHP_EOL .
+            'Processed a recurring nudge with %s users' . \PHP_EOL .
+            'Total time processing: %s seconds or %s minutes' . \PHP_EOL .
+            '------' .
+            \str_repeat(\PHP_EOL, 2),
+            $usercount,
+            $total,
+            $total / 60
+        );
+
+        $this->assertEquals($usercount, $sink->count(), 'There was an inconsistant ammount of message sent.');
+    }
+
+    /**
+     * @testdox Benchmarking fixed nudge
+     */
+    public function test_send_benchmark_fixed(): void
+    {
+        $usercount = 4_000;
+
+        // -------------------------------
+        //          SETUP TEST
+        // -------------------------------
+        /** @var \core_config $CFG */
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->preventResetByRollback();
+
+        $sink = $this->redirectMessages();
+
+        // -------------------------------
+        //          SETUP DATA
+        // -------------------------------
+
+        $time = \time();
+        $CFG->nudgemocktime = $time;
+
+        $course = $this->getDataGenerator()->create_course([]);
+        $sender = $this->getDataGenerator()->create_user();
+        for ($i = $usercount; $i--; $i != 0) {
+            $this->getDataGenerator()->create_and_enrol(
+                $course,
+                'student',
+                null,
+                'manual',
+                $time
+            );
+        }
+
+        // TODO: dataGenerators for nudge, notification and contents.
+        $notification = nudge_notification_db::create_or_refresh(
+            new nudge_notification(['userfromid' => $sender->id])
+        );
+        nudge_notification_content_db::create_or_refresh(new nudge_notification_content([
+            'nudgenotificationid' => $notification->id
+        ]));
+
+        nudge_db::create_or_refresh(new nudge([
+            'isenabled' => 1,
+            'courseid' => $course->id,
+            'linkedlearnernotificationid' => $notification->id,
+            'remindertype' => nudge::REMINDER_DATE_INPUT_FIXED,
+            // Send reminder 2 minutes after enrollment.
+            'remindertypefixeddate' => $time + 1
+        ]));
+
+        // -------------------------------
+        //      PERFORM ASSERTIONS
+        // -------------------------------
+
+        (new nudge_task)->execute();
+
+        $this->assertEquals(0, $sink->count(), 'There should be an no message to any user yet.');
+
+        $CFG->nudgemocktime += 1;
+
+        $start = \time();
+        (new nudge_task)->execute();
+        $total = \time() - $start;
+        printf(
+            \str_repeat(\PHP_EOL, 2) .
+            '------' . \PHP_EOL .
+            'Processed a recurring nudge with %s users' . \PHP_EOL .
+            'Total time processing: %s seconds or %s minutes' . \PHP_EOL .
+            '------' .
+            \str_repeat(\PHP_EOL, 2),
+            $usercount,
+            $total,
+            $total / 60
+        );
+
+        $this->assertEquals($usercount, $sink->count(), 'There was an inconsistant ammount of message sent.');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Requires 3.9.0.
-$plugin->version   = 2022022803;
+$plugin->version   = 2022022804;
 $plugin->requires  = 2020061500;
 $plugin->component = 'local_nudge';
 $plugin->release   = 'Development Edition';


### PR DESCRIPTION
Loosely split into commits but not atomic ones they were all created after the fact.

Notable changes:
 - New reminder type to fit the requirements better - Non-recurring and relative date to course enrolment
 - UI improvements
 - Automated security checks and suggestions
 - "Nudge is broken" messages sent to owners when nudge's linked messages are deleted.
 - Removal of nudges when its course is deleted
 - Huge increase in test coverage
 
@robinpetterd what do you think of the naming in the [note at the top of the readme](https://github.com/sproutlabs/moodle-local_nudge/blob/95c863bcf7e0ac412841c32a0da27065223a753c/README.md#note)? 