### PR TITLE
Feature - Course completion nudges

### DIFF
--- a/classes/event/course_completed_observer.php
+++ b/classes/event/course_completed_observer.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// phpcs:disable moodle.Commenting
+
+namespace local_nudge\event;
+
+use core\event\course_completed;
+use local_nudge\dml\nudge_db;
+use local_nudge\local\nudge;
+
+/**
+ * @package     local_nudge\event
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+class course_completed_observer {
+    /**
+     * Trigger all nudges for this course and user that should be triggered on course completion.
+     *
+     * @param course_completed $event
+     */
+    public static function trigger_course_completion_nudges(course_completed $event): void {
+        /** @var \moodle_database $DB */
+        global $DB;
+
+        /** @var nudge[] */
+        $nudgestotrigger = nudge_db::get_all_filtered([
+            'remindertype' => nudge::REMINDER_DATE_COURSE_COMPLETION,
+            'courseid' => $event->courseid
+        ]);
+
+        foreach ($nudgestotrigger as $nudge) {
+            /** @var \core\entity\user|\stdClass */
+            $user = $DB->get_record('user', ['id' => $event->relateduserid], '*', \MUST_EXIST);
+            $nudge->trigger($user);
+        }
+    }
+}

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -226,6 +226,8 @@ class edit extends moodleform {
             case (nudge::REMINDER_DATE_RELATIVE_COURSE_END):
                 $instancedata['remindertypeperiod'] = $data->reminderdaterelativecourseend;
                 break;
+            case (nudge::REMINDER_DATE_COURSE_COMPLETION):
+                break;
             default:
                 // UNREACHABLE!.
                 throw new moodle_exception(

--- a/classes/local/nudge.php
+++ b/classes/local/nudge.php
@@ -65,6 +65,11 @@ class nudge extends abstract_nudge_entity {
      * This Nudge instance's reminder timing recurrs based on the user's date of enrollment.
      */
     public const REMINDER_DATE_RELATIVE_ENROLLMENT_RECURRING = 'enrollmentrecurring';
+
+    /**
+     * This Nudge instance's reminder timing is based on course completion
+     */
+    public const REMINDER_DATE_COURSE_COMPLETION = 'coursecompletion';
     // END ENUM - REMINDER DATE    ////////////////////
 
     // BEGIN ENUM - REMINDER RECIPIENT    ////////////////////

--- a/db/events.php
+++ b/db/events.php
@@ -22,12 +22,15 @@
  * @license     GNU GPL v3 or later
  */
 
+use core\event\course_completed;
+use local_nudge\event\course_completed_observer;
+
 defined('MOODLE_INTERNAL') || die();
 
-// phpcs:ignore
-// Requires 3.9.0.
-$plugin->version   = 2022022807;
-$plugin->requires  = 2020061500;
-$plugin->component = 'local_nudge';
-$plugin->release   = 'Release Candidate 1';
-$plugin->maturity  = MATURITY_RC;
+$observers = [
+    [
+        'eventname' => course_completed::class,
+        'callback' => course_completed_observer::class . '::trigger_course_completion_nudges',
+        'internal' => false, // Happy to run after transaction.
+    ]
+];

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -153,10 +153,11 @@ $string['form_notification_deleteconfirm']                          =       'Are
 // See: local/nudge/lib.php::nudge_scaffold_select_from_constants()
 // ---------------------------------------
 // Reminder Date
-$string['reminderdateinputfixed']                                   =       'Reminder Date Input Fixed';
-$string['reminderdaterelativeenrollment']                           =       'Reminder Date Relative Enrollment';
-$string['reminderdaterelativeenrollmentrecurring']                  =       'Reminder Date Relative Enrollment Recurring';
-$string['reminderdaterelativecourseend']                            =       'Reminder Date Relative Course End';
+$string['reminderdateinputfixed']                                   =       'Reminder Date input fixed';
+$string['reminderdaterelativeenrollment']                           =       'Reminder Date relative enrollment';
+$string['reminderdaterelativeenrollmentrecurring']                  =       'Reminder Date relative enrollment recurring';
+$string['reminderdaterelativecourseend']                            =       'Reminder Date relative Course end';
+$string['reminderdatecoursecompletion']                             =       'Remind on Course completion';
 
 // Reminder Recipient
 $string['reminderrecipientlearner']                                 =       'The Learner';

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -111,10 +111,11 @@ class lib_test extends advanced_testcase {
                 nudge::class,
                 'REMINDER_DATE',
                 [
-                    'fixed' => 'Reminder Date Input Fixed',
-                    'courseend' => 'Reminder Date Relative Course End',
-                    'enrollment' => 'Reminder Date Relative Enrollment',
-                    'enrollmentrecurring' => 'Reminder Date Relative Enrollment Recurring',
+                    'fixed' => 'Reminder Date input fixed',
+                    'courseend' => 'Reminder Date relative Course end',
+                    'enrollment' => 'Reminder Date relative enrollment',
+                    'enrollmentrecurring' => 'Reminder Date relative enrollment recurring',
+                    'coursecompletion' => 'Remind on Course completion',
                 ]
             ],
             'Nudge\'s REMINDER_RECIPIENT' => [

--- a/tests/testclasses/event/course_completion_observer_test.php
+++ b/tests/testclasses/event/course_completion_observer_test.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_nudge\tests
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+namespace local_nudge\testclasses\event;
+
+use advanced_testcase;
+use completion_completion;
+use local_nudge\dml\nudge_db;
+use local_nudge\dml\nudge_notification_content_db;
+use local_nudge\dml\nudge_notification_db;
+use local_nudge\local\nudge;
+use local_nudge\local\nudge_notification;
+use local_nudge\local\nudge_notification_content;
+use stdClass;
+
+// phpcs:disable moodle.Commenting
+// phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
+// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine
+
+/**
+ * @testdox When using a nudge with timing based on course completion
+ * @coversDefaultClass \local_nudge\event\course_completed_observer
+ */
+class course_completion_observer_test extends advanced_testcase {
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     * @testdox a message is sent on course completion
+     * @covers ::trigger_course_completion_nudges
+     */
+    public function test_nudge_triggered_on_course_completion(): void
+    {
+        /** @var \core_config */
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->preventResetByRollback();
+
+        $sink = $this->redirectMessages();
+
+        /** @var \core\entity\course|stdClass */
+        $course = $this->getDataGenerator()->create_course();
+
+        /** @var \core\entity\user|stdClass */
+        $user = $this->getDataGenerator()->create_and_enrol($course);
+
+        $notification = nudge_notification_db::create_or_refresh(
+            new nudge_notification(['userfromid' => $user->id])
+        );
+        $contents = nudge_notification_content_db::create_or_refresh(new nudge_notification_content([
+            'nudgenotificationid' => $notification->id,
+            'subject' => 'xyz',
+            'body' => 'xyz'
+        ]));
+        $nudge = new nudge([
+            'isenabled' => true,
+            'courseid' => $course->id,
+            'linkedlearnernotificationid' => $notification->id,
+            'remindertype' => nudge::REMINDER_DATE_COURSE_COMPLETION,
+        ]);
+
+        nudge_db::save($nudge);
+
+        $this->assertEquals(0, $sink->count());
+
+        $coursecompletion = new completion_completion([
+            'course' => $course->id,
+            'userid' => $user->id,
+        ]);
+        $coursecompletion->mark_complete();
+
+        // Check the correct ammount of emails were sent.
+        if ($CFG->branch == '39') {
+            // Only nudge.
+            $expectedcount = 1;
+        } else {
+            // Nudge **and** the default moodle completion message introduced in 310.
+            $expectedcount = 2;
+        }
+        $this->assertEquals($expectedcount, $sink->count());
+
+        $this->assertIsArray($sink->get_messages());
+        $message = $sink->get_messages()[0];
+        $this->assertIsObject($message);
+
+        $this->assertEquals('local_nudge', $message->component);
+        $this->assertEquals($contents->subject, $message->subject);
+        $this->assertEquals($contents->body, $message->fullmessage);
+        $this->assertEquals($contents->body, $message->fullmessagehtml);
+        $this->assertEquals($user->id, $message->useridfrom);
+        $this->assertEquals($user->id, $message->useridto);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}
+


### PR DESCRIPTION
This PR adds the ability to send nudges on course completion.

This was a requested feature from Bradken since it is not default in Totara (But is in moodle, as the test notes).

The overall implementation is fairly elegant, It simplely observes course completion then calls ->trigger() on relevant nudge.