### PR TITLE
Various changes to translations and UX.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE']
+        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE']
         database: [mariadb]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-# NOTE
-This plugin is not yet stable.
-There is rename that is going to happen to avoid conflicts with the L&D nudge but we are yet to decide on naming.
-## Maybe:
-Plugin is local_completionreminder and models:
- - CourseTracker (nudge)
- - Notification (nudge_notification)
- - Translation (nudge_notification_content)
-
 # :point_right: Nudge
 > The Nudge plugin for MOODLE and Totara aims to provide a simple way to notify/remind users to revisit their course prior to course completion.
 >> The pugin supports multiple translation, templated messages, recurring remind dates, relative remind dates and the option to remind managers in both Totara *and MOODLE*.
@@ -15,8 +6,6 @@ Plugin is local_completionreminder and models:
 | :------------------------------------ |
 | [What this is not](#what-this-is-not) |
 | [Contributing](#contributing)         |
-| [TODOs](#todos)                       |
-| [IDEAs](#ideas)                       |
 | [Versioning](#versioning)             |
 | [Installation](#installation)         |
 | [Credits](#credits)                   |
@@ -37,16 +26,6 @@ Plugin is local_completionreminder and models:
 
 ## Contributing
 Welcomed :-)
-
-## TODOs
- 1. Migrate ideas and TODOs to GH issues.
- 1. TODO flesh out readme.
- 1. Installation process written up.
- 1. Initial user guide.
- 1. Initial developer guide.
-
-## IDEAs 
- 1. IDEA: Benchmark phpunit testsuite to run a different test suite that tests operations in bulk numerous 1000s then reports on time.
 
 ## Versioning
 | PHP Version |       LMS Version        |             Nudge Branch             |

--- a/backup/moodle2/backup_local_nudge_plugin.class.php
+++ b/backup/moodle2/backup_local_nudge_plugin.class.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_nudge
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+use local_nudge\dml\nudge_db;
+
+class backup_local_nudge_plugin extends backup_local_plugin {
+
+    protected function define_course_plugin_structure() {
+        $plugin = $this->get_plugin_element(null);
+
+        $pluginwrapper = new backup_nested_element($this->get_recommended_name());
+        $nudges = new backup_nested_element('nudges');
+        $elements = [
+            'courseid',
+            // We can just directly reuse these has ones since the notifications and their contents exists in a site context.
+            'linkedlearnernotificationid',
+            'linkedmanagernotificationid',
+            'title',
+            // No need to backup isenabled since it will always be disabled.
+            'reminderrecipient',
+            'remindertype',
+            'remindertypefixeddate',
+            'remindertypeperiod',
+        ];
+        $nudge = new backup_nested_element('nudge', ['id'], $elements);
+
+        $plugin->add_child($pluginwrapper);
+        $pluginwrapper->add_child($nudges);
+        $nudges->add_child($nudge);
+
+        $courseid = backup_helper::is_sqlparam($this->get_setting_value(backup::VAR_COURSEID));
+        $nudge->set_source_table(nudge_db::$table, ['courseid' => $courseid]);
+
+        $nudge->annotate_ids('courseid', 'courseid');
+
+        return $plugin;
+    }
+}

--- a/backup/moodle2/restore_local_nudge_plugin.class.php
+++ b/backup/moodle2/restore_local_nudge_plugin.class.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use local_nudge\dml\nudge_db;
+use local_nudge\local\nudge;
+
+/**
+ * @package     local_nudge
+ * @author      Liam Kearney <liam@sproutlabs.com.au>
+ * @copyright   (c) 2022, Sprout Labs { @see https://sproutlabs.com.au }
+ * @license     http://www.gnu.org/copyleft/gpl.html
+ * @license     GNU GPL v3 or later
+ */
+
+class restore_local_nudge_plugin extends restore_local_plugin {
+
+    protected function define_course_plugin_structure() {
+        return [
+            new restore_path_element('local_nudge_nudge', $this->get_pathfor('/nudges/nudge'))
+        ];
+    }
+
+    /**
+     * @param array $data
+     */
+    public function process_local_nudge_nudge($data) {
+        $nudge = new nudge($data);
+        // Nudges should always restore disabled. This is to prevent unexpected messages around relative timings.
+        $nudge->isenabled = false;
+        $nudge->courseid = $this->get_mappingid('course', $data['courseid']);
+
+        // Created by and timecreated will also be reset due to the id unset which is nice.
+        unset($nudge->id);
+        nudge_db::save($nudge);
+    }
+}

--- a/classes/form/nudge/edit.php
+++ b/classes/form/nudge/edit.php
@@ -138,7 +138,8 @@ class edit extends moodleform {
             get_string('form_nudge_remindertyperelativedate', 'local_nudge'),
             [
                 // Default to days.
-                'defaultunit' => \DAYSECS
+                'defaultunit' => \DAYSECS,
+                'units' => [\HOURSECS, \DAYSECS, \WEEKSECS]
             ]
         );
         $mform->setDefault('reminderdaterelativeenrollment', 86400);
@@ -151,7 +152,8 @@ class edit extends moodleform {
             get_string('form_nudge_remindertyperelativedaterecurring', 'local_nudge'),
             [
                 // Default to days.
-                'defaultunit' => \DAYSECS
+                'defaultunit' => \DAYSECS,
+                'units' => [\HOURSECS, \DAYSECS, \WEEKSECS]
             ]
         );
         $mform->setDefault('reminderdaterelativeenrollmentrecurring', 86400);
@@ -173,7 +175,8 @@ class edit extends moodleform {
             get_string('form_nudge_reminderdatecourseend', 'local_nudge'),
             [
                 // Default to days.
-                'defaultunit' => \DAYSECS
+                'defaultunit' => \DAYSECS,
+                'units' => [HOURSECS, DAYSECS, WEEKSECS]
             ]
         );
         $mform->hideIf('reminderdaterelativecourseend', 'remindertype', 'neq', nudge::REMINDER_DATE_RELATIVE_COURSE_END);

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -26,6 +26,7 @@
 
 namespace local_nudge\local;
 
+use local_nudge\dml\nudge_db;
 use local_nudge\dml\nudge_notification_content_db;
 use local_nudge\dto\nudge_notification_form_data;
 use local_nudge\local\abstract_nudge_entity;
@@ -151,13 +152,22 @@ class nudge_notification extends abstract_nudge_entity {
      * @return array<mixed>
      */
     public function get_summary_fields(): array {
+        /** @var \moodle_database $DB */
+        global $DB;
+
         $notificationcount = count($this->get_contents());
         $possibleplurals = ($notificationcount != 1) ? 's' : '';
         $pluralreferer = ($notificationcount > 1) ? 'are' : 'is';
+        $linkednudgecount = $DB->count_records_select(nudge_db::$table, <<<SQL
+        linkedlearnernotificationid = ? OR linkedmanagernotificationid = ?
+        SQL, [$this->id, $this->id]); // Yeah this is the best way todo multiple indentical params, moodle is great..
         return [
             $this->get_notification_edit_link(),
             <<<HTML
                 <p class="badge badge-primary">There {$pluralreferer} {$notificationcount} linked translation{$possibleplurals}</p>
+            HTML,
+            <<<HTML
+                <p class="badge badge-info">$linkednudgecount linked nudges</p>
             HTML
         ];
     }

--- a/classes/local/nudge_notification.php
+++ b/classes/local/nudge_notification.php
@@ -127,13 +127,13 @@ class nudge_notification extends abstract_nudge_entity {
                     'local_nudge'
                 );
             }
+            $languagelist = \get_string_manager()->get_list_of_languages();
             $languagenotsupportedwarning = get_string(
                 'languagenotsupported',
                 'local_nudge',
                 [
                     'langcode' => $userslangcode,
-                    'language' => \get_string_manager()
-                        ->get_list_of_languages()[$userslangcode] ?? 'ERROR: We can\'t offer a language name for this language code',
+                    'language' => $languagelist[$userslangcode] ?? 'ERROR: We can\'t offer a language name for this language code',
                 ]
             );
             $notificationcontent->body .= <<<HTML

--- a/classes/task/nudge_task.php
+++ b/classes/task/nudge_task.php
@@ -53,6 +53,7 @@ require_once(__DIR__ . '/../../lib.php');
  * should be recommended in the readme for serious use of the plugin.
  */
 class nudge_task extends scheduled_task {
+    /** @todo Account for enrol status. SEE comment at: lib/db/install.xml:266 */
     private const USER_COURSE_ENROLLMENT_TIME_SQL = <<<SQL
     SELECT
         timestart

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -232,9 +232,9 @@ $string['admin_ux_addtranslationcount_desc']                        =       <<<E
 The amount of translations to add each time when creating a Nudge Notification.
 EOF;
 
-$string['admin_ux_enddate']                                         =       'Start date';
+$string['admin_ux_enddate']                                         =       'End date';
 $string['admin_ux_enddate_desc']                                    =       <<<EOF
-You can select a start date here to limit date pickers.
+You can select a end date here to limit date pickers to something reasonable.
 EOF;
 
 // Performance Settings

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -172,14 +172,14 @@ $string['reminderrecipientboth']                                    =       'Bot
 $string['configurenudge']                                           =       'Configure Nudge';
 $string['manage_settings']                                          =       'Configure Nudge Settings';
 
-// Managers settings
-$string['admin_manager_heading']                                    =       'Manager Settings';
+// Manager resolution settings.
+$string['admin_manager_heading']                                    =       'Manager resolution Settings';
 $string['admin_manager_heading_desc']                               =       <<<EOF
 These are just for emulation on MOODLE, Totara already has a system for this.
 EOF;
 
-$string['admin_custom_managerresolution']                           =       'Custom manager resolution enabled';
-$string['admin_custom_managerresolution_desc']                      =       <<<EOF
+$string['admin_manager_managerresolution']                          =       'Custom manager resolution enabled';
+$string['admin_manager_managerresolution_desc']                     =       <<<EOF
 If this is enabled the below two fields will be used for custom manager resolution.
 In Totara this is generally not a good idea however this is <em><strong>needed</strong> for MOODLE solutions</em>.
 EOF;
@@ -195,6 +195,30 @@ $string['admin_manager_matchon_field_desc']                         =       <<<E
 This field will be used to match managers on.
 This is the "unique" identifier for a manager
 EOF;
+
+// Language resolution settings.
+$string['admin_language_heading']                                   =       'Language resolution settings';
+$string['admin_language_heading_desc']                              =       <<<'HTML'
+<div class="alert alert-info p-3 pt-4 mt-4">
+    <p>By default this plugin uses the user's language preference in MOODLE however in some cases you may wish
+        to base the user's email message language on a custom profile field.</p>
+    <p>It is <strong>important to note</strong> that a custom field must exist before you can select it here.</p>
+</div>
+HTML;
+
+$string['admin_language_languageresolution']                        =       'Custom language resolution enabled';
+$string['admin_language_languageresolution_desc']                   =       <<<EOF
+If this is enabled language preference will be based on the below selected custom field rather than
+the inbuilt moodle system.
+EOF;
+
+$string['admin_language_field']                                     =       'Custom language field';
+$string['admin_language_field_desc']                                =       <<<'HTML'
+<p>This is the field that will be used as the user's preference language.</p>
+<p>You <strong>must ensure</strong> that this field is considered a valid MOODLE/Totara language code.</p>
+<center>See <a href="https://download.moodle.org/langpack/4.0/">here</a> for MOODLE language codes (the prefix before the zip file)
+    and <a href="https://download.totaralms.com/lang/T16/">here</a> for Totara ones.</center>
+HTML;
 
 // UX Settings
 $string['admin_ux_heading']                                         =       'User Experience Settings';
@@ -261,6 +285,11 @@ $string['messageprovider:owneremail']                               =       'Nud
 // ---------------------------------------
 //               EXCEPTIONS
 // ---------------------------------------
+$string['languagenotsupported']                                     =       <<<'HTML'
+<p>Your language is not supported, The primary translation has been offered for now.</p>
+<p>Please contact a Site Administrator and notify them that a translation for your
+    language: {$a->langcode} ({$a->language}) is not offered.</p>
+HTML;
 $string['cantmanagesitenudges']                                     =       'You can\'t attach nudge reminders to the site course.';
 $string['nudge_exception_unlinked_notification_subject']            =       '{$a} - Exception for a nudge you manage';
 $string['nudge_exception_unlinked_notification_body']               =       <<<'HTML'

--- a/lang/en/local_nudge.php
+++ b/lang/en/local_nudge.php
@@ -61,6 +61,7 @@ $string['manage_nudge_col_actions']                                 =       'Act
 $string['manage_notification_add']                                  =       'Add a Nudge Notification';
 $string['manage_notification_col_title']                            =       'Title';
 $string['manage_notification_col_count']                            =       'Linked Translation Count';
+$string['manage_notification_col_nudge_count']                      =       'Linked Nudges';
 $string['manage_notification_col_actions']                          =       'Actions';
 
 

--- a/lib.php
+++ b/lib.php
@@ -329,6 +329,9 @@ function nudge_get_managers_for_user($user): array {
             get_config('local_nudge', 'managermatchonfield') == null ||
             get_config('local_nudge', 'managermatchwithfield') == null
         ) {
+            if (debugging()) {
+                mtrace("Failed to resolve manager for user {$user->id}, manager resolution is on but is not setup correctly.");
+            }
             throw new moodle_exception(
                 'cantmatchmanager',
                 'local_nudge',
@@ -403,6 +406,9 @@ function nudge_moodle_get_manager_for_user($user): ?stdClass {
     // @codeCoverageIgnoreStart
     } catch (dml_exception $e) {
         // TODO: Log failed to find manager.
+        if (debugging()) {
+            mtrace("Failed to find manager for user {$user->id}, Match on: {$matchonfield}, Match with: {$matchwith}");
+        }
         return null;
     }
     // @codeCoverageIgnoreEnd

--- a/lib.php
+++ b/lib.php
@@ -190,8 +190,8 @@ function nudge_get_email_message($nudge, $user, $manager = null): message {
         $notification = $nudge->get_manager_notification();
     }
 
-    $notificationcontents = $notification->get_contents($user->lang);
-    $notificationcontent = array_pop($notificationcontents);
+    $notificationcontent = $notification->get_users_contents($user);
+
     /** @var \core\entity\user|stdClass|false */
     $userfrom = $DB->get_record('user', ['id' => $notification->userfromid]);
     $course = $nudge->get_course();
@@ -267,6 +267,26 @@ function nudge_hydrate_notification_template(
     $result = \strtr($contenttotemplate, $templatevars);
 
     return $result;
+}
+
+/**
+ * Get a user's language respecting the config option to use profile fields.
+ *
+ * @access public
+ *
+ * @param \core\entity\user|stdClass $user
+ *
+ * @return string
+ */
+function nudge_get_user_language_code(stdClass $user): ?string {
+    $userprofilefieldused = (bool) get_config('local_nudge', 'customlanguageresolution');
+    if (!$userprofilefieldused) {
+        return $user->lang;
+    } else {
+        $profilefield = get_config('local_nudge', 'customlanguagefield');
+        profile_load_data($user);
+        return $user->{"profile_field_{$profilefield}"};
+    }
 }
 
 /**

--- a/manage_notifications.php
+++ b/manage_notifications.php
@@ -61,15 +61,18 @@ $table->define_baseurl(new \moodle_url('/local/nudge/manage_notifications.php'))
 $table->define_columns([
     'title',
     'count',
+    'nudgecount',
     'actions',
 ]);
 $table->define_headers([
     get_string('manage_notification_col_title', 'local_nudge'),
     get_string('manage_notification_col_count', 'local_nudge'),
+    get_string('manage_notification_col_nudge_count', 'local_nudge'),
     get_string('manage_notification_col_actions', 'local_nudge'),
 ]);
 $table->sortable(true, 'title');
 $table->no_sorting('count');
+$table->no_sorting('nudgecount');
 $table->no_sorting('actions');
 $table->setup();
 

--- a/settings.php
+++ b/settings.php
@@ -101,8 +101,8 @@ if ($hassiteconfig) {
             ),
             new admin_setting_configcheckbox(
                 'local_nudge/custommangerresolution',
-                get_string('admin_custom_managerresolution', 'local_nudge'),
-                get_string('admin_custom_managerresolution_desc', 'local_nudge'),
+                get_string('admin_manager_managerresolution', 'local_nudge'),
+                get_string('admin_manager_managerresolution_desc', 'local_nudge'),
                 '0',
             ),
             new admin_setting_configselect(
@@ -116,6 +116,25 @@ if ($hassiteconfig) {
                 'local_nudge/managermatchwithfield',
                 get_string('admin_manager_matchwith_field', 'local_nudge'),
                 get_string('admin_manager_matchwith_field_desc', 'local_nudge'),
+                '',
+                $customfieldsselect,
+            ),
+            // Custom language resolution section.
+            new admin_setting_heading(
+                'nudge_admin_language_heading',
+                get_string('admin_language_heading', 'local_nudge'),
+                get_string('admin_language_heading_desc', 'local_nudge'),
+            ),
+            new admin_setting_configcheckbox(
+                'local_nudge/customlanguageresolution',
+                get_string('admin_language_languageresolution', 'local_nudge'),
+                get_string('admin_language_languageresolution_desc', 'local_nudge'),
+                '0',
+            ),
+            new admin_setting_configselect(
+                'local_nudge/customlanguagefield',
+                get_string('admin_language_field', 'local_nudge'),
+                get_string('admin_language_field_desc', 'local_nudge'),
                 '',
                 $customfieldsselect,
             ),

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -345,6 +345,29 @@ class lib_test extends advanced_testcase {
 
     /**
      * @test
+     * @testdox When getting a user's language code it should conditionally use a user's custom profile field based on config.
+     * @covers ::nudge_get_user_language_code
+     */
+    public function test_nudge_get_user_language_code(): void
+    {
+        $this->resetAfterTest();
+
+        $this->create_profile_field('userlanguage');
+
+        $user = $this->getDataGenerator()->create_user([
+            'profile_field_userlanguage' => 'en_us',
+        ]);
+
+        $this->assertSame('en', nudge_get_user_language_code($user));
+
+        set_config('customlanguageresolution', '1', 'local_nudge');
+        set_config('customlanguagefield', 'userlanguage', 'local_nudge');
+
+        $this->assertSame('en_us', nudge_get_user_language_code($user));
+    }
+
+    /**
+     * @test
      * @testdox TODO totara testing?
      * @covers ::nudge_totara_get_managers_for_user
      *

--- a/tests/testclasses/local/abstract_nudge_entity_test.php
+++ b/tests/testclasses/local/abstract_nudge_entity_test.php
@@ -78,7 +78,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
      * @test
      * @testdox Supplying a $_dataName constructs without issue.
      * @dataProvider provide_construct_with_valid_data
-     * @covers local_nudge\local\abstract_nudge_entity::__construct
+     * @covers \local_nudge\local\abstract_nudge_entity::__construct
      */
     public function test_contruct_with_valid_data($data): void
     {
@@ -112,7 +112,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
      * @test
      * @testdox Supplying $_dataName to an entities constructor fails gracefully.
      * @dataProvider provide_construct_with_invalid_data
-     * @covers local_nudge\local\abstract_nudge_entity::__construct
+     * @covers \local_nudge\local\abstract_nudge_entity::__construct
      */
     public function test_contruct_with_invalid_data($data, $exception): void
     {
@@ -124,7 +124,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox Constructing without data works fine.
-     * @covers local_nudge\local\abstract_nudge_entity::__construct
+     * @covers \local_nudge\local\abstract_nudge_entity::__construct
      */
     public function test_contruct_with_no_data(): void
     {
@@ -140,7 +140,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox Saving will result in createdby being set to the current user.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_set_and_update_createdby(): void
     {
@@ -167,7 +167,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox Createdby will not be changed.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_immutable_createdby(): void
     {
@@ -190,7 +190,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox Saving will result in timecreated being set to current time.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_set_and_update_timecreated(): void
     {
@@ -212,7 +212,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox Timecreated will not be changed.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_immutable_timecreated(): void
     {
@@ -238,7 +238,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox When saving lastmodifiedby will be set to the current user and change when updated.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_set_and_update_lastmodifedby(): void
     {
@@ -266,7 +266,7 @@ class abstract_nudge_entity_test extends advanced_testcase {
     /**
      * @test
      * @testdox When saving lastmodified will be set to the current time and changed when updated.
-     * @covers local_nudge\dml\nudge_db::save
+     * @covers \local_nudge\dml\nudge_db::save
      */
     public function test_set_and_update_lastmodifed(): void
     {

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 // phpcs:ignore
 // Requires 3.9.0.
-$plugin->version   = 2022022807;
+$plugin->version   = 2022022808;
 $plugin->requires  = 2020061500;
 $plugin->component = 'local_nudge';
 $plugin->release   = 'Release Candidate 1';


### PR DESCRIPTION
- Backup support (needed for Totara programs to function, certifications might cause issues at the moment / need to be looked into).
- If a notification doesn't have a translation for a specific language it will fallback on one it does have (and notify the user).
- Language can now be determined from custom profile fields rather than user's language preference.
- Added tests for the new code related to translation failovers and custom profile languages.
- You can now no longer setup a nudge to occur with granularity of seconds or minutes.
- Nudge notifications now display their linked nudge count
- CI: Now running the tests on MOODLE 4.0 out of curiosity.
